### PR TITLE
Idempotent tests

### DIFF
--- a/lib/postgresql_interface.js
+++ b/lib/postgresql_interface.js
@@ -26,8 +26,8 @@ PostgresqlInterface.prototype.summonTransaction =
   // If it worked, go ahead with transaction
   // If duplicate, fetch status and return
   var self = this;
-  this.client.query('INSERT INTO transactions (id, status, deviceFingerprint, ' +
-      'toAddress, satoshis, currencyCode, fiat) ' + 
+  this.client.query('INSERT INTO transactions (id, status, "deviceFingerprint", ' +
+      '"toAddress", satoshis, "currencyCode", fiat) ' + 
       'VALUES ($1, $2, $3, $4, $5, $6, $7)', [tx.txId, 'pending', deviceFingerprint,
       tx.toAddress, tx.satoshis, tx.currencyCode, tx.fiat], 
       function (err) {
@@ -47,7 +47,7 @@ PostgresqlInterface.prototype.reportTransactionError =
 PostgresqlInterface.prototype.completeTransaction = 
   function completeTransaction(tx, txHash) {
   if (txHash)
-    this.client.query('UPDATE transactions SET txHash=$1, status=$2, completed=now() WHERE id=$3', 
+    this.client.query('UPDATE transactions SET "txHash"=$1, status=$2, completed=now() WHERE id=$3', 
       [txHash, 'completed', tx.txId]);
   else
     this.client.query('UPDATE transactions SET status=$1, error=$2 WHERE id=$3', 
@@ -56,14 +56,14 @@ PostgresqlInterface.prototype.completeTransaction =
 
 PostgresqlInterface.prototype._fetchTransaction = 
     function _fetchTransaction(txId, cb) {
-  this.client.query('SELECT status, txHash FROM transactions WHERE id=$1',
-      [txId], function (err, rows) {
+  this.client.query('SELECT status, "txHash" FROM transactions WHERE id=$1',
+      [txId], function (err, results) {
     if (err) return cb(err);
 
     // This should never happen, since we already checked for existence
-    if (rows === 0) return cb(new Error('Couldn\'t find transaction.')); 
+    if (results.rows.length === 0) return cb(new Error('Couldn\'t find transaction.')); 
 
-    var result = rows[0];
+    var result = results.rows[0];
     cb(null, false, result.txHash);
   });
 };

--- a/test/unit/traderSendTest.js
+++ b/test/unit/traderSendTest.js
@@ -12,7 +12,11 @@ var psqlInterface = new PostgresqlInterface(db);
 var TRANSACTION_FEE = 1;
 var FINGERPRINT = 'CB:3D:78:49:03:39:BA:47:0A:33:29:3E:31:25:F7:C6:4F:74:71:D7';
 var TXID = '216dabdb692670bae940deb71e59486038a575f637903d3c9af601ddd48057fc';
+var ADDRESS = '1LhkU2R8nJaU8Zj6jB8VjWrMpvVKGqCZ64';
+var SATOSHIS = 1337;
 var CURRENCY = 'USD';
+
+var OUR_TXID = uuid();
 
 describe('trader/send', function () {
   var trader = new Trader(psqlInterface);
@@ -27,14 +31,10 @@ describe('trader/send', function () {
   trader.pollRate = function () {};
 
   it('should call `sendBitcoins` on the transfer exchange', function (done) {
-    var address = '1LhkU2R8nJaU8Zj6jB8VjWrMpvVKGqCZ64';
-    var txId = uuid();
-    var satoshis = 1337;
-
     trader.transferExchange = {
-      sendBitcoins: function (address_, satoshis_, transactionFee, callback) {
-        assert.equal(address, address_);
-        assert.equal(satoshis, satoshis_);
+      sendBitcoins: function (address, satoshis, transactionFee, callback) {
+        assert.equal(ADDRESS, address);
+        assert.equal(SATOSHIS, satoshis);
         assert.equal(transactionFee, TRANSACTION_FEE);
         callback(null, TXID);
       }
@@ -42,10 +42,30 @@ describe('trader/send', function () {
 
     trader.sendBitcoins(FINGERPRINT, {
       fiat: 100,
-      txId: txId,
+      txId: OUR_TXID,
       currencyCode: CURRENCY,
-      toAddress: address,
-      satoshis: satoshis
+      toAddress: ADDRESS,
+      satoshis: SATOSHIS
+    }, function (err, txId) {
+      assert.notOk(err);
+      assert.equal(txId, TXID);
+      done();
+    });
+  });
+
+  it('should not call `sendBitcoins` on the transfer exchange with same send', function (done) {
+    trader.transferExchange = {
+      sendBitcoins: function () {
+        throw new Error('This should not have been called');
+      }
+    };
+
+    trader.sendBitcoins(FINGERPRINT, {
+      fiat: 100,
+      txId: OUR_TXID,
+      currencyCode: CURRENCY,
+      toAddress: ADDRESS,
+      satoshis: SATOSHIS
     }, function (err, txId) {
       assert.notOk(err);
       assert.equal(txId, TXID);


### PR DESCRIPTION
@joshmh this fixes and adds tests for idempotent send. It's a branch on top of `atm-protocol-merge` so that review is easier.
