### PR TITLE
Add back balance and ticker logging, add lamassu-snapcard

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -409,7 +409,8 @@ function stopTrader() {
 }
 
 function pollBalance(cb) {
-
+  logger.debug('collecting balance');
+  
   var jobs = {
     transferBalance: walletPlugin.balance
   };
@@ -426,6 +427,7 @@ function pollBalance(cb) {
       return cb && cb(err);
     }
 
+    logger.debug('Balance update:', balance);
     balance.timestamp = Date.now();
     lastBalances = balance;
 
@@ -434,12 +436,15 @@ function pollBalance(cb) {
 }
 
 function pollRate(cb) {
+  logger.debug('polling for rates (%s)', tickerPlugin.NAME);
+  
   tickerPlugin.ticker(deviceCurrency, function(err, resRates) {
     if (err) {
       logger.error(err);
       return cb && cb(err);
     }
 
+    logger.debug('got rates: %j', resRates);
     resRates.timestamp = new Date();
     lastRates = resRates;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lamassu-server",
   "description": "bitcoin atm client server protocol module",
   "keywords": [],
-  "version": "2.2.10",
+  "version": "2.2.11",
   "license": "unlicense",
   "author": "Lamassu (https://lamassu.is)",
   "engines": {
@@ -26,7 +26,8 @@
     "lamassu-coinbase": "^1.0.4",
     "lamassu-coinapult": "^0.4.5",
     "lamassu-coinfloor": "^0.1.2",
-    "lamassu-bitgo": "^0.1.3",
+    "lamassu-bitgo": "^0.1.7",
+    "lamassu-snapcard": "^0.1.7",
     "lodash": "^2.4.1",
     "minimist": "0.0.8",
     "node-uuid": "^1.4.2",


### PR DESCRIPTION
By operator request, allows for confirmation that the wallet provider is retrieving a balance and that the ticker is working as expected. While more verbose, archived server logs are easy enough to obtain if one needs to look backward.

Adds lamassu-snapcard for wallet and bumps required lamassu-bitgo version. Installs well.