### PR TITLE
Update zcashd and geth

### DIFF
--- a/blockchains/zcash/install.sh
+++ b/blockchains/zcash/install.sh
@@ -9,9 +9,9 @@ ufw allow 8233 >> $LOG_FILE 2>&1
 ufw allow 22 >> $LOG_FILE 2>&1
 ufw --force enable >> $LOG_FILE 2>&1
 ufw status >> $LOG_FILE 2>&1
-wget -q https://z.cash/downloads/zcash-1.0.11-linux64.tar.gz >> $LOG_FILE 2>&1
-tar -xzf zcash-1.0.11-linux64.tar.gz >> $LOG_FILE 2>&1
-cp zcash-1.0.11/bin/* /usr/local/bin >> $LOG_FILE 2>&1
+wget -q https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz >> $LOG_FILE 2>&1
+tar -xzf zcash-1.0.12-linux64.tar.gz >> $LOG_FILE 2>&1
+cp zcash-1.0.12/bin/* /usr/local/bin >> $LOG_FILE 2>&1
 zcash-fetch-params >> $LOG_FILE 2>&1
 mkdir ~/.zcash >> $LOG_FILE 2>&1
 mv /tmp/zcash.conf ~/.zcash

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -26,8 +26,8 @@ const BINARIES = {
     dir: 'geth-linux-amd64-1.6.6-10a45cb5'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-1.0.10-1-linux64.tar.gz',
-    dir: 'zcash-1.0.10-1/bin'
+    url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',
+    dir: 'zcash-1.0.12/bin'
   },
   DASH: {
     url: 'https://www.dash.org/binaries/dashcore-0.12.1.5-linux64.tar.gz',

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -22,8 +22,8 @@ const BINARIES = {
     dir: 'bitcoin-0.14.2/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.6-10a45cb5.tar.gz',
-    dir: 'geth-linux-amd64-1.6.6-10a45cb5'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz',
+    dir: 'geth-linux-amd64-1.7.2-1db4ecdc.tar.gz'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -23,7 +23,7 @@ const BINARIES = {
   },
   ETH: {
     url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz',
-    dir: 'geth-linux-amd64-1.7.2-1db4ecdc.tar.gz'
+    dir: 'geth-linux-amd64-1.7.2-1db4ecdc'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',


### PR DESCRIPTION
As Zcash has a monthly release cycle now, we should consider implementing the `-disabledeprecation=1.0.12` config flag.