### PR TITLE
Update Zcash and Litecoin

### DIFF
--- a/blockchains/litecoin/install.sh
+++ b/blockchains/litecoin/install.sh
@@ -9,9 +9,9 @@ ufw allow 8332 >> $LOG_FILE 2>&1
 ufw allow 22 >> $LOG_FILE 2>&1
 ufw --force enable >> $LOG_FILE 2>&1
 ufw status >> $LOG_FILE 2>&1
-wget -q https://download.litecoin.org/litecoin-0.13.2/linux/litecoin-0.13.2-x86_64-linux-gnu.tar.gz >> $LOG_FILE 2>&1
-tar -xzf litecoin-0.13.2-x86_64-linux-gnu.tar.gz >> $LOG_FILE 2>&1
-cp litecoin-0.13.2/bin/* /usr/local/bin >> $LOG_FILE 2>&1
+wget -q https://download.litecoin.org/litecoin-0.14.2/linux/litecoin-0.14.2-x86_64-linux-gnu.tar.gz >> $LOG_FILE 2>&1
+tar -xzf litecoin-0.14.2-x86_64-linux-gnu.tar.gz >> $LOG_FILE 2>&1
+cp litecoin-0.14.2/bin/* /usr/local/bin >> $LOG_FILE 2>&1
 mkdir ~/.litecoin >> $LOG_FILE 2>&1
 mv /tmp/litecoin.conf ~/.litecoin
 mv /tmp/supervisor-litecoin.conf /etc/supervisor/conf.d/litecoin.conf >> $LOG_FILE 2>&1

--- a/blockchains/zcash/install.sh
+++ b/blockchains/zcash/install.sh
@@ -16,4 +16,5 @@ zcash-fetch-params >> $LOG_FILE 2>&1
 mkdir ~/.zcash >> $LOG_FILE 2>&1
 mv /tmp/zcash.conf ~/.zcash
 mv /tmp/supervisor-zcash.conf /etc/supervisor/conf.d/zcash.conf >> $LOG_FILE 2>&1
+sed -i '2s/$/ -disabledeprecation=1.0.12/' /etc/supervisor/conf.d/zcash.conf >> $LOG_FILE 2>&1
 service supervisor restart >> $LOG_FILE 2>&1

--- a/blockchains/zcash/install.sh
+++ b/blockchains/zcash/install.sh
@@ -16,5 +16,4 @@ zcash-fetch-params >> $LOG_FILE 2>&1
 mkdir ~/.zcash >> $LOG_FILE 2>&1
 mv /tmp/zcash.conf ~/.zcash
 mv /tmp/supervisor-zcash.conf /etc/supervisor/conf.d/zcash.conf >> $LOG_FILE 2>&1
-sed -i '2s/$/ -disabledeprecation=1.0.12/' /etc/supervisor/conf.d/zcash.conf >> $LOG_FILE 2>&1
 service supervisor restart >> $LOG_FILE 2>&1

--- a/blockchains/zcash/install.sh
+++ b/blockchains/zcash/install.sh
@@ -9,9 +9,9 @@ ufw allow 8233 >> $LOG_FILE 2>&1
 ufw allow 22 >> $LOG_FILE 2>&1
 ufw --force enable >> $LOG_FILE 2>&1
 ufw status >> $LOG_FILE 2>&1
-wget -q https://z.cash/downloads/zcash-1.0.11-linux64.tar.gz >> $LOG_FILE 2>&1
-tar -xzf zcash-1.0.11-linux64.tar.gz >> $LOG_FILE 2>&1
-cp zcash-1.0.11/bin/* /usr/local/bin >> $LOG_FILE 2>&1
+wget -q https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz >> $LOG_FILE 2>&1
+tar -xzf zcash-1.0.12-linux64.tar.gz >> $LOG_FILE 2>&1
+cp zcash-1.0.12/bin/* /usr/local/bin >> $LOG_FILE 2>&1
 zcash-fetch-params >> $LOG_FILE 2>&1
 mkdir ~/.zcash >> $LOG_FILE 2>&1
 mv /tmp/zcash.conf ~/.zcash

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -26,8 +26,8 @@ const BINARIES = {
     dir: 'geth-linux-amd64-1.6.6-10a45cb5'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-1.0.10-1-linux64.tar.gz',
-    dir: 'zcash-1.0.10-1/bin'
+    url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',
+    dir: 'zcash-1.0.12/bin'
   },
   DASH: {
     url: 'https://www.dash.org/binaries/dashcore-0.12.1.5-linux64.tar.gz',

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -22,8 +22,8 @@ const BINARIES = {
     dir: 'bitcoin-0.14.2/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.6-10a45cb5.tar.gz',
-    dir: 'geth-linux-amd64-1.6.6-10a45cb5'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz',
+    dir: 'geth-linux-amd64-1.7.2-1db4ecdc.tar.gz'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -34,8 +34,8 @@ const BINARIES = {
     dir: 'dashcore-0.12.1/bin'
   },
   LTC: {
-    url: 'https://download.litecoin.org/litecoin-0.13.2/linux/litecoin-0.13.2-x86_64-linux-gnu.tar.gz',
-    dir: 'litecoin-0.13.2/bin'
+    url: 'https://download.litecoin.org/litecoin-0.14.2/linux/litecoin-0.14.2-x86_64-linux-gnu.tar.gz',
+    dir: 'litecoin-0.14.2/bin'
   }
 }
 

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -23,7 +23,7 @@ const BINARIES = {
   },
   ETH: {
     url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz',
-    dir: 'geth-linux-amd64-1.7.2-1db4ecdc.tar.gz'
+    dir: 'geth-linux-amd64-1.7.2-1db4ecdc'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.12-linux64.tar.gz',

--- a/lib/blockchain/zcash.js
+++ b/lib/blockchain/zcash.js
@@ -20,7 +20,7 @@ function setup (dataDir) {
   logger.info('Finished fetching proofs.')
   const config = buildConfig()
   common.writeFile(path.resolve(dataDir, coinRec.configFile), config)
-  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir}`
+  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir} -disabledeprecation=1.0.12`
   common.writeSupervisorConfig(coinRec, cmd)
 }
 


### PR DESCRIPTION
Update Litecoin, Zcash, and add `-disabledeprecation=1.0.12` flag to zcashd command.