### PR TITLE
Add Bitpay ticker for BCH

### DIFF
--- a/lib/admin/config.js
+++ b/lib/admin/config.js
@@ -167,7 +167,7 @@ function fetchData () {
     languages: languages,
     countries,
     accounts: [
-      {code: 'bitpay', display: 'Bitpay', class: 'ticker', cryptos: ['BTC']},
+      {code: 'bitpay', display: 'Bitpay', class: 'ticker', cryptos: ['BTC', 'BCH']},
       {code: 'kraken', display: 'Kraken', class: 'ticker', cryptos: ['BTC', 'ETH', 'LTC', 'DASH', 'ZEC', 'BCH']},
       {code: 'bitstamp', display: 'Bitstamp', class: 'ticker', cryptos: ['BTC', 'LTC']},
       {code: 'coinbase', display: 'Coinbase', class: 'ticker', cryptos: ['BTC', 'ETH', 'LTC']},

--- a/lib/plugins/ticker/bitpay/bitpay.js
+++ b/lib/plugins/ticker/bitpay/bitpay.js
@@ -2,11 +2,11 @@ const axios = require('axios')
 const BN = require('../../../bn')
 
 function ticker (account, fiatCode, cryptoCode) {
-  if (cryptoCode !== 'BTC') {
+  if (!_.includes(cryptoCode, ['BTC', 'BCH'])) {
     return Promise.reject('Unsupported crypto: ' + cryptoCode)
   }
 
-  return axios.get('https://bitpay.com/api/rates/' + fiatCode)
+  return axios.get('https://bitpay.com/api/rates/' + cryptoCode '/' + fiatCode)
   .then(r => {
     const data = r.data
     const price = BN(data.rate)

--- a/lib/plugins/ticker/bitpay/bitpay.js
+++ b/lib/plugins/ticker/bitpay/bitpay.js
@@ -2,11 +2,8 @@ const axios = require('axios')
 const BN = require('../../../bn')
 
 function ticker (account, fiatCode, cryptoCode) {
-  if (!_.includes(cryptoCode, ['BTC', 'BCH'])) {
-    return Promise.reject('Unsupported crypto: ' + cryptoCode)
-  }
 
-  return axios.get('https://bitpay.com/api/rates/' + cryptoCode '/' + fiatCode)
+  return axios.get('https://bitpay.com/api/rates/' + cryptoCode + '/' + fiatCode)
   .then(r => {
     const data = r.data
     const price = BN(data.rate)


### PR DESCRIPTION
Bitpay now provides a BCH ticker, and will be more reliable than Kraken.