### PR TITLE
Update node wallet versions

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -25,15 +25,15 @@ const BINARIES = {
     dir: 'bitcoin-0.15.1/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz',
-    dir: 'geth-linux-amd64-1.7.2-1db4ecdc'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz',
+    dir: 'geth-linux-amd64-1.7.3-4bb3c89d'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-1.0.13-linux64.tar.gz',
-    dir: 'zcash-1.0.13/bin'
+    url: 'https://z.cash/downloads/zcash-1.0.14-linux64.tar.gz',
+    dir: 'zcash-1.0.14/bin'
   },
   DASH: {
-    url: 'https://github.com/dashpay/dash/releases/download/v0.12.2.1/dashcore-0.12.2.1-linux64.tar.gz',
+    url: 'https://github.com/dashpay/dash/releases/download/v0.12.2.3/dashcore-0.12.2.3-linux64.tar.gz',
     dir: 'dashcore-0.12.2/bin'
   },
   LTC: {
@@ -41,8 +41,8 @@ const BINARIES = {
     dir: 'litecoin-0.14.2/bin'
   },
   BCH: {
-    url: 'https://download.bitcoinabc.org/0.16.1/linux/bitcoin-abc-0.16.1-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-abc-0.16.1/bin',
+    url: 'https://download.bitcoinabc.org/0.16.2/linux/bitcoin-abc-0.16.2-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-abc-0.16.2/bin',
     files: [['bitcoind', 'bitcoincashd'], ['bitcoin-cli', 'bitcoincash-cli']]
   }
 }

--- a/lib/blockchain/zcash.js
+++ b/lib/blockchain/zcash.js
@@ -20,7 +20,7 @@ function setup (dataDir) {
   logger.info('Finished fetching proofs.')
   const config = buildConfig()
   common.writeFile(path.resolve(dataDir, coinRec.configFile), config)
-  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir} -disabledeprecation=1.0.13`
+  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir} -disabledeprecation=1.0.14`
   common.writeSupervisorConfig(coinRec, cmd)
 }
 


### PR DESCRIPTION
This version of Bitcoin ABC includes CashAddr support (default).