### PR TITLE
Trade on USD Kraken if fiat is other than USD/EUR

### DIFF
--- a/lib/plugins/exchange/kraken/kraken.js
+++ b/lib/plugins/exchange/kraken/kraken.js
@@ -19,7 +19,11 @@ function trade (account, type, cryptoAtoms, fiatCode, cryptoCode) {
   const kraken = new Kraken(account.apiKey, account.privateKey, {timeout: 30000})
   const amount = common.toUnit(cryptoAtoms, cryptoCode)
   const amountStr = amount.toFixed(6)
-  const pair = PAIRS[cryptoCode][fiatCode]
+  if (fiatCode = ['USD', 'EUR']) {
+    const pair = PAIRS[cryptoCode][fiatCode]
+  } else {
+    const pair = PAIRS[cryptoCode]['USD']
+  }
 
   var orderInfo = {
     pair: pair,

--- a/lib/plugins/exchange/kraken/kraken.js
+++ b/lib/plugins/exchange/kraken/kraken.js
@@ -23,7 +23,7 @@ function trade (account, type, cryptoAtoms, fiatCode, cryptoCode) {
 
   const pair = _.includes(fiatCode, ['USD', 'EUR']) 
   ? PAIRS[cryptoCode][fiatCode]
-  : PAIRS[cryptoCode]['USD']
+  : PAIRS[cryptoCode]['EUR']
   
   var orderInfo = {
     pair,

--- a/lib/plugins/exchange/kraken/kraken.js
+++ b/lib/plugins/exchange/kraken/kraken.js
@@ -1,5 +1,6 @@
 // Note: Using DeX3/npm-kraken-api to adjust timeout time
 const Kraken = require('kraken-api')
+const _ = require('lodash/fp')
 
 const common = require('../../common/kraken')
 
@@ -19,15 +20,14 @@ function trade (account, type, cryptoAtoms, fiatCode, cryptoCode) {
   const kraken = new Kraken(account.apiKey, account.privateKey, {timeout: 30000})
   const amount = common.toUnit(cryptoAtoms, cryptoCode)
   const amountStr = amount.toFixed(6)
-  if (fiatCode = ['USD', 'EUR']) {
-    const pair = PAIRS[cryptoCode][fiatCode]
-  } else {
-    const pair = PAIRS[cryptoCode]['USD']
-  }
 
+  const pair = _.includes(fiatCode, ['USD', 'EUR']) 
+  ? PAIRS[cryptoCode][fiatCode]
+  : PAIRS[cryptoCode]['USD']
+  
   var orderInfo = {
-    pair: pair,
-    type: type,
+    pair,
+    type,
     ordertype: 'market',
     volume: amountStr,
     expiretm: '+60'


### PR DESCRIPTION
If a machine currency is other than USD or EUR, Kraken trades will fail because pair is not defined in `common/kraken.js` (and not offered by Kraken).

Instead, trade on USD market.