### PR TITLE
handle cash-out errors when tx.bills is not set

### DIFF
--- a/lib/cash-out-tx.js
+++ b/lib/cash-out-tx.js
@@ -177,6 +177,7 @@ function nextHd (isHd, tx) {
 }
 
 function dispenseOccurred (bills) {
+  if (!bills) return false
   return _.every(_.overEvery([_.has('dispensed'), _.has('rejected')]), bills)
 }
 


### PR DESCRIPTION
From an operator:

> In some cases, tx.bills is not set.  This seems to occur when the transaction is over the 0-conf limit, and confirmation does not occur while the user is waiting at the machine, so basically anything that gets redeemed later.  When this happens, we get this on the server:
```
Jan 29 15:31:39 no lamassu-server[6273]: GET /tx?phone=%2B[REDACTED] 200 14.053 ms - 717
Jan 29 15:31:39 no lamassu-server[6273]: DEBUG100
Jan 29 15:31:39 no lamassu-server[6273]: 2018-01-29T20:31:39.874Z - error:  TypeError: Cannot read property '0' of undefined
Jan 29 15:31:39 no lamassu-server[6273]: at updateCassettes (/usr/local/src/lamassu-v5/lamassu-server/lib/cash-out-tx.js:193:13)
Jan 29 15:31:39 no lamassu-server[6273]: at Promise.resolve.then.updatedTx (/usr/local/src/lamassu-v5/lamassu-server/lib/cash-out-tx.js:250:13)
Jan 29 15:31:39 no lamassu-server[6273]: POST /tx?rid=5f57325d-4f66-4843-b4ab-626a77f603d3 500 18.452 ms - 49
```
> I believe this is fixed with this patch in lib/cash-out-tx.js. This has been tested, and seems to work in all cases.  We currently have it running live.