### PR TITLE
ETH performance

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -25,8 +25,8 @@ const BINARIES = {
     dir: 'bitcoin-0.15.1/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz',
-    dir: 'geth-linux-amd64-1.7.3-4bb3c89d'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.0-5f540757.tar.gz',
+    dir: 'geth-linux-amd64-1.8.0-5f540757'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.14-linux64.tar.gz',

--- a/lib/blockchain/ethereum.js
+++ b/lib/blockchain/ethereum.js
@@ -7,6 +7,6 @@ module.exports = {setup}
 function setup (dataDir) {
   const coinRec = coinUtils.getCryptoCurrency('ETH')
   common.firewall([coinRec.defaultPort])
-  const cmd = `/usr/local/bin/${coinRec.daemon} --datadir "${dataDir}" --syncmode="fast" --cache 500 --rpc`
+  const cmd = `/usr/local/bin/${coinRec.daemon} --datadir "${dataDir}" --syncmode="fast" --cache 2048 --maxconnections 40 --rpc`
   common.writeSupervisorConfig(coinRec, cmd)
 }


### PR DESCRIPTION
As we're recommending a 16 GB RAM droplet for ETH, we have overhead to increase the cache usage during syncing and to increase peer connections (default is 25).

Whereas fast mode on 1.8.0 with 500 MB cache / 25 peers would not keep in sync (see https://github.com/ethereum/go-ethereum/issues/15001), increasing RAM usage to 2 GB and allowing up to 40 peers allowed full sync in under a half-day and subsequently stayed in sync.