### PR TITLE
Fix ETH peers and bump to 1.8.1

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -25,8 +25,8 @@ const BINARIES = {
     dir: 'bitcoin-0.15.1/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.0-5f540757.tar.gz',
-    dir: 'geth-linux-amd64-1.8.0-5f540757'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.1-1e67410e.tar.gz',
+    dir: 'geth-linux-amd64-1.8.1-1e67410e'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.14-linux64.tar.gz',

--- a/lib/blockchain/ethereum.js
+++ b/lib/blockchain/ethereum.js
@@ -7,6 +7,6 @@ module.exports = {setup}
 function setup (dataDir) {
   const coinRec = coinUtils.getCryptoCurrency('ETH')
   common.firewall([coinRec.defaultPort])
-  const cmd = `/usr/local/bin/${coinRec.daemon} --datadir "${dataDir}" --syncmode="fast" --cache 2048 --maxconnections 40 --rpc`
+  const cmd = `/usr/local/bin/${coinRec.daemon} --datadir "${dataDir}" --syncmode="fast" --cache 2048 --maxpeers 40 --rpc`
   common.writeSupervisorConfig(coinRec, cmd)
 }


### PR DESCRIPTION
Corrects `maxconnections` to `maxpeers`, updates geth to 1.8.1.