### PR TITLE
Trade on EUR Bitstamp if fiat other than USD/EUR

### DIFF
--- a/lib/plugins/exchange/bitstamp/bitstamp.js
+++ b/lib/plugins/exchange/bitstamp/bitstamp.js
@@ -1,4 +1,5 @@
 const common = require('../../common/bitstamp')
+const _ = require('lodash/fp')
 
 const SATOSHI_SHIFT = 8
 
@@ -23,6 +24,10 @@ function handleErrors (data) {
 }
 
 function trade (type, account, cryptoAtoms, fiatCode, cryptoCode) {
+  if (!_.includes(fiatCode, ['USD', 'EUR'])) {
+    fiatCode = 'EUR'
+  }
+
   try {
     const market = common.buildMarket(fiatCode, cryptoCode)
     const options = {amount: cryptoAtoms.shift(-SATOSHI_SHIFT).toFixed(8)}


### PR DESCRIPTION
If a machine currency is other than USD or EUR, Bitstamp trades currently fail. Instead, trade on EUR market.