### PR TITLE
Update BTC client, native SegWit

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -21,8 +21,8 @@ module.exports = {
 
 const BINARIES = {
   BTC: {
-    url: 'https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-0.15.1/bin'
+    url: 'https://bitcoin.org/bin/bitcoin-core-0.16.0/bitcoin-0.16.0-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-0.16.0/bin'
   },
   ETH: {
     url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.1-1e67410e.tar.gz',


### PR DESCRIPTION
Uses SegWit (P2SH) addresses as default. Adds support for bech32.