### PR TITLE
Fix BadNumberError code

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -171,7 +171,7 @@ function getCustomerWithPhoneCode (req, res, next) {
     })
   })
   .catch(err => {
-    if (err.name === 'BadNumberError') throw httpError('Bad number', 410)
+    if (err.name === 'BadNumberError') throw httpError('Bad number', 401)
     throw err
   })
   .catch(next)


### PR DESCRIPTION
When an incorrect phone number is given, lamassu-machine expects a 401 error code, but lamassu-server was returning 410 instead, leading to machine hangs in the 'waiting' state.