### PR TITLE
Support CashAddr format

### DIFF
--- a/lib/admin/config.js
+++ b/lib/admin/config.js
@@ -169,7 +169,7 @@ function fetchData () {
         {crypto: 'LTC', display: 'Litecoin'},
         {crypto: 'DASH', display: 'Dash'},
         {crypto: 'ZEC', display: 'Zcash'},
-        {crypto: 'BCH', display: 'BCH'}
+        {crypto: 'BCH', display: 'Bitcoin Cash'}
       ],
       languages: languages,
       countries,

--- a/lib/coin-utils.js
+++ b/lib/coin-utils.js
@@ -52,7 +52,7 @@ const CRYPTO_CURRENCIES = [
   },
   {
     cryptoCode: 'BCH',
-    display: 'BCH',
+    display: 'Bitcoin Cash',
     code: 'bitcoincash',
     configFile: 'bitcoincash.conf',
     daemon: 'bitcoincashd',
@@ -80,7 +80,7 @@ function buildUrl (cryptoCode, address) {
     case 'ZEC': return `zcash:${address}`
     case 'LTC': return `litecoin:${address}`
     case 'DASH': return `dash:${address}`
-    case 'BCH': return `bitcoincash:${address}`
+    case 'BCH': return `${address}`
     default: throw new Error(`Unsupported crypto: ${cryptoCode}`)
   }
 }

--- a/lib/plugins/wallet/bitcoincashd/bitcoincashd.js
+++ b/lib/plugins/wallet/bitcoincashd/bitcoincashd.js
@@ -1,6 +1,5 @@
 const jsonRpc = require('../../common/json-rpc')
 
-const bs58check = require('bs58check')
 const BN = require('../../../bn')
 const E = require('../../../error')
 const coinUtils = require('../../../coin-utils')
@@ -37,29 +36,11 @@ function balance (account, cryptoCode) {
   return accountBalance(account, cryptoCode, 1)
 }
 
-function bchToBtcVersion (version) {
-  if (version === 0x1c) return 0x00
-  if (version === 0x28) return 0x05
-
-  return version
-}
-
-// Bitcoin-ABC only accepts BTC style addresses at this point,
-// so we need to convert
-function bchToBtcAddress (address) {
-  const buf = bs58check.decode(address)
-  const version = buf[0]
-  buf[0] = bchToBtcVersion(version)
-  return bs58check.encode(buf)
-}
-
 function sendCoins (account, address, cryptoAtoms, cryptoCode) {
   const coins = cryptoAtoms.shift(-unitScale).toFixed(8)
 
-  const btcAddress = bchToBtcAddress(address)
-
   return checkCryptoCode(cryptoCode)
-    .then(() => fetch('sendtoaddress', [btcAddress, coins]))
+    .then(() => fetch('sendtoaddress', [address, coins]))
     .catch(err => {
       if (err.code === -6) throw new E.InsufficientFundsError()
       throw err
@@ -72,9 +53,7 @@ function newAddress (account, info) {
 }
 
 function addressBalance (address, confs) {
-  const btcAddress = bchToBtcAddress(address)
-
-  return fetch('getreceivedbyaddress', [btcAddress, confs])
+  return fetch('getreceivedbyaddress', [address, confs])
     .then(r => BN(r).shift(unitScale).round())
 }
 

--- a/lib/plugins/wallet/bitcoind/bitcoind.js
+++ b/lib/plugins/wallet/bitcoind/bitcoind.js
@@ -24,7 +24,7 @@ function checkCryptoCode (cryptoCode) {
   return Promise.resolve()
 }
 
-function accountBalance (acount, cryptoCode, confirmations) {
+function accountBalance (account, cryptoCode, confirmations) {
   return checkCryptoCode(cryptoCode)
     .then(() => fetch('getbalance', ['', confirmations]))
     .then(r => BN(r).shift(unitScale).round())


### PR DESCRIPTION
Remove BCH address conversion to support CashAddr format natively.

Switch machine display back to 'Bitcoin Cash'. No need to avoid confusion as we're only allowing for CashAddr at the machine.