### PR TITLE
Update ZEC & BCH for hardforks, ETH release

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -29,8 +29,8 @@ const BINARIES = {
     dir: 'geth-linux-amd64-1.8.3-329ac18e'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-1.0.15-linux64.tar.gz',
-    dir: 'zcash-1.0.15/bin'
+    url: 'https://z.cash/downloads/zcash-1.1.0-linux64.tar.gz',
+    dir: 'zcash-1.1.0/bin'
   },
   DASH: {
     url: 'https://github.com/dashpay/dash/releases/download/v0.12.2.3/dashcore-0.12.2.3-linux64.tar.gz',

--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -25,8 +25,8 @@ const BINARIES = {
     dir: 'bitcoin-0.16.0/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.2-b8b9f7f4.tar.gz',
-    dir: 'geth-linux-amd64-1.8.2-b8b9f7f4'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.3-329ac18e.tar.gz',
+    dir: 'geth-linux-amd64-1.8.3-329ac18e'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-1.0.15-linux64.tar.gz',
@@ -41,8 +41,8 @@ const BINARIES = {
     dir: 'litecoin-0.15.1/bin'
   },
   BCH: {
-    url: 'https://download.bitcoinabc.org/0.16.2/linux/bitcoin-abc-0.16.2-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-abc-0.16.2/bin',
+    url: 'https://download.bitcoinabc.org/0.17.0/linux/bitcoin-abc-0.17.0-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-abc-0.17.0/bin',
     files: [['bitcoind', 'bitcoincashd'], ['bitcoin-cli', 'bitcoincash-cli']]
   }
 }

--- a/lib/blockchain/zcash.js
+++ b/lib/blockchain/zcash.js
@@ -20,7 +20,7 @@ function setup (dataDir) {
   logger.info('Finished fetching proofs.')
   const config = buildConfig()
   common.writeFile(path.resolve(dataDir, coinRec.configFile), config)
-  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir} -disabledeprecation=1.0.15`
+  const cmd = `/usr/local/bin/${coinRec.daemon} -datadir=${dataDir} -disabledeprecation=1.1.0`
   common.writeSupervisorConfig(coinRec, cmd)
 }
 


### PR DESCRIPTION
ZEC will hardfork upgrade on 25 June. v1.1.0 is compatible with new consensus changes.

BCH will hardfork upgrade on 15 May. v0.17.0 is compatible with new consensus changes.

ETH update to address network DoS attacks.