### PR TITLE
Fix migrate-tools for multiple devices

### DIFF
--- a/migrations/migrate-tools.js
+++ b/migrations/migrate-tools.js
@@ -7,10 +7,10 @@ const machineLoader = require('../lib/machine-loader')
 module.exports = {migrateNames}
 
 function migrateNames () {
-  const cs = new pgp.helpers.ColumnSet(['device_id', 'name'], {table: 'devices'})
+  const cs = new pgp.helpers.ColumnSet(['?device_id', 'name'], {table: 'devices'})
 
   return settingsLoader.loadLatest()
     .then(r => machineLoader.getMachineNames(r.config))
     .then(_.map(r => ({device_id: r.deviceId, name: r.name})))
-    .then(data => pgp.helpers.update(data, cs))
+    .then(data => pgp.helpers.update(data, cs) + ' WHERE t.device_id=v.device_id')
 }


### PR DESCRIPTION
Don't fail with duplicate key errors if there is more than one row already in the devices table, since it attempts to update the device_id column.