### PR TITLE
phone_code API bugfix

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -180,7 +180,7 @@ function addOrUpdateCustomer (req) {
       return customers.add(req.body)
     })
     .then(customer => {
-      return compliance.validationPatch(config, customer)
+      return compliance.validationPatch(req.deviceId, config, customer)
         .then(patch => {
           if (_.isEmpty(patch)) return customer
           return customers.update(customer.id, patch)


### PR DESCRIPTION
This was causing

`error: TypeError: Cannot read property 'sanctionsOverride' of undefined
at validateOfac (lamassu-server/lib/compliance.js:63:16)
at Object.validationPatch (lamassu-server/lib/compliance.js:71:10)
at customers.get.then.then.customer (lamassu-server/lib/routes.js:183:25)
at <anonymous>`