### PR TITLE
Remove sample format on Twilio panel

### DIFF
--- a/schemas/twilio.json
+++ b/schemas/twilio.json
@@ -18,15 +18,14 @@
     },
     {
       "code": "fromNumber",
-      "display": "From number",
+      "display": "Twilio number (international format)",
       "fieldType": "string",
       "required": true,
-      "placeholder": "+14155552671",
       "value": ""
     },
     {
       "code": "toNumber",
-      "display": "To number",
+      "display": "Notifications number (international format)",
       "fieldType": "string",
       "required": true,
       "value": ""


### PR DESCRIPTION
The placeholder number is being consistently mistaken as belonging there. Better to leave it off, and specify 'international format' here and in documentaiton.

'From' and 'To' can be rendered more descriptive as 'Twilio' and 'Notifications' numbers.