### PR TITLE
Add 'caution' warning to mock wallet

### DIFF
--- a/lib/admin/config.js
+++ b/lib/admin/config.js
@@ -191,7 +191,7 @@ function fetchData () {
         {code: 'bitgo', display: 'BitGo', class: 'wallet', cryptos: ['BTC']},
         {code: 'bitstamp', display: 'Bitstamp', class: 'exchange', cryptos: ['BTC', 'ETH', 'LTC', 'BCH']},
         {code: 'kraken', display: 'Kraken', class: 'exchange', cryptos: ['BTC', 'ETH', 'LTC', 'DASH', 'ZEC', 'BCH']},
-        {code: 'mock-wallet', display: 'Mock wallet', class: 'wallet', cryptos: ALL_CRYPTOS},
+        {code: 'mock-wallet', display: 'Mock (Caution!)', class: 'wallet', cryptos: ALL_CRYPTOS},
         {code: 'no-exchange', display: 'No exchange', class: 'exchange', cryptos: ALL_CRYPTOS},
         {code: 'mock-exchange', display: 'Mock exchange', class: 'exchange', cryptos: ALL_CRYPTOS},
         {code: 'mock-sms', display: 'Mock SMS', class: 'sms'},


### PR DESCRIPTION
If mock wallet is used in production on a two-way machine, would allow for dispensing cash without sending coins. Add 'caution' to the admin (in addition to current warnings in support documentation).