### PR TITLE
config-validator to consider default values from schema

### DIFF
--- a/bin/cert-gen.sh
+++ b/bin/cert-gen.sh
@@ -78,7 +78,6 @@ cat <<EOF > $CONFIG_DIR/lamassu.json
   "hostname": "$DOMAIN",
   "logLevel": "debug",
   "lamassuCaPath": "$LAMASSU_CA_PATH",
-  "lamassuServerPath": "$PWD",
   "migrateStatePath": "$MIGRATE_STATE_PATH",
   "ofacDataDir": "$OFAC_DATA_DIR",
   "ofacSources": [

--- a/install
+++ b/install
@@ -158,7 +158,6 @@ cat <<EOF > $CONFIG_DIR/lamassu.json
   "keyPath": "$SERVER_KEY_PATH",
   "hostname": "$IP",
   "logLevel": "info",
-  "lamassuServerPath": "$NODE_MODULES/lamassu-server",
   "migrateStatePath": "$MIGRATE_STATE_PATH",
   "blockchainDir": "$BLOCKCHAIN_DIR",
   "ofacDataDir": "$OFAC_DATA_DIR",

--- a/lamassu-default.json
+++ b/lamassu-default.json
@@ -4,7 +4,6 @@
   "certPath": "/etc/ssl/certs/Lamassu_OP.pem",
   "keyPath": "/etc/ssl/private/Lamassu_OP.key",
   "logLevel": "info",
-  "lamassuServerPath": "/usr/local/share/.config/yarn/global/node_modules/lamassu-server",
   "migrateStatePath": "/etc/lamassu/.migrate",
   "blockchainDir": "/mnt/blockchains",
   "ofacDataDir": "/opt/lamassu-server/sanctions",

--- a/lib/admin/admin-server.js
+++ b/lib/admin/admin-server.js
@@ -100,8 +100,10 @@ app.post('/api/account', (req, res) => {
     .then(() => dbNotify())
 })
 
-app.get('/api/config/:config', (req, res) =>
-  config.fetchConfigGroup(req.params.config).then(c => res.json(c)))
+app.get('/api/config/:config', (req, res, next) =>
+  config.fetchConfigGroup(req.params.config)
+    .then(c => res.json(c))
+    .catch(next))
 
 app.post('/api/config', (req, res, next) => {
   config.saveConfigGroup(req.body)

--- a/lib/admin/config.js
+++ b/lib/admin/config.js
@@ -1,6 +1,3 @@
-const pify = require('pify')
-const fs = pify(require('fs'))
-const path = require('path')
 const _ = require('lodash/fp')
 
 const currencies = require('../../currencies.json')
@@ -9,16 +6,13 @@ const countries = require('../../countries.json')
 const settingsLoader = require('../settings-loader')
 
 const db = require('../db')
-const options = require('../options')
 const configManager = require('../config-manager')
 const configValidate = require('../config-validate')
 const machineLoader = require('../machine-loader')
+const jsonSchema = require('../../lamassu-schema.json')
 
 function fetchSchema () {
-  const schemaPath = path.resolve(options.lamassuServerPath, 'lamassu-schema.json')
-
-  return fs.readFile(schemaPath)
-    .then(JSON.parse)
+  return _.cloneDeep(jsonSchema)
 }
 
 function fetchConfig () {

--- a/lib/config-validate.js
+++ b/lib/config-validate.js
@@ -52,8 +52,9 @@ function satisfiesRequire (config, cryptos, machineList, field, anyFields, allFi
     const isBlank = _.isNil(configManager.scopedValue(scope[0], scope[1], fieldCode, config))
     const isRequired = (_.isEmpty(anyFields) || isAnyEnabled()) &&
       (_.isEmpty(allFields) || areAllEnabled())
+    const hasDefault = !_.isNil(_.get('default', field))
 
-    const isValid = isRequired ? !isBlank : true
+    const isValid = !isRequired || !isBlank || hasDefault
 
     return isValid
   })

--- a/lib/migrate-options.js
+++ b/lib/migrate-options.js
@@ -25,11 +25,14 @@ async function run () {
   const currentOpts = options.opts
 
   // check if there are new options to add
-  const result = _.mergeAll([defaultOpts, currentOpts])
-  const shouldMigrate = !_.isEqual(result, currentOpts)
+  let result = _.mergeAll([defaultOpts, currentOpts])
+  const shouldMigrate = !_.isEqual(result, currentOpts) || _.has('lamassuServerPath', result)
 
   // write the resulting lamassu.json
   if (shouldMigrate) {
+    // remove old lamassuServerPath config
+    result = _.omit('lamassuServerPath', result)
+
     const newOpts = _.pick(_.difference(_.keys(result), _.keys(currentOpts)), result)
     console.log('Adding options', newOpts)
 


### PR DESCRIPTION
This is to solve https://gist.github.com/naconner/1f1e668ca69039675f581efcb602423d#file-gistfile1-txt-L73

To test you can take the last user_config and remove all the terms related configs from the array.
Then when you start l-a server you'll see the config-validator error.

This change is to make it consider also defaults from the schema in case the config value is missing (like in this case when we were migrating from an old version)