### PR TITLE
Improve serialization error handling on cash_out

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,6 +25,7 @@ const argv = require('minimist')(process.argv.slice(2))
 
 const CLOCK_SKEW = 60 * 1000
 const REQUEST_TTL = 3 * 60 * 1000
+const SERIALIZATION_FAILURE_CODE = '40001'
 
 const pids = {}
 const reboots = {}
@@ -134,6 +135,7 @@ function postTx (req, res, next) {
       return res.json(tx)
     })
     .catch(err => {
+      if (err.code === SERIALIZATION_FAILURE_CODE) return res.status(204).json({})
       if (err instanceof E.StaleTxError) return res.status(409).json({})
       if (err instanceof E.RatchetError) return res.status(409).json({})
 


### PR DESCRIPTION
Made API calls return 204 on serialization error.

When network is unreliable there is a high chance of generating a
serialization exception. By returnig 204 on them the lamassu-machine can
just continue to work as if nothing happened.

[Trello card](https://trello.com/c/WaVHCVw1/600-db-serialization-bug-read-write-deps#)