### PR TITLE
Add device_id to cash_out_actions table

### DIFF
--- a/lib/cash-out/cash-out-actions.js
+++ b/lib/cash-out/cash-out-actions.js
@@ -18,7 +18,7 @@ function logActionById (t, action, _rec, txId) {
 }
 
 function logAction (t, action, _rec, tx) {
-  const rec = _.assign(_rec, {action, tx_id: tx.id, redeem: !!tx.redeem})
+  const rec = _.assign(_rec, {action, tx_id: tx.id, redeem: !!tx.redeem, device_id: tx.deviceId})
   const sql = pgp.helpers.insert(rec, null, 'cash_out_actions')
 
   return t.none(sql)

--- a/migrations/1536651947391-add-device-id-to-cash-out-actions.js
+++ b/migrations/1536651947391-add-device-id-to-cash-out-actions.js
@@ -1,0 +1,12 @@
+var db = require('./db')
+
+exports.up = function (next) {
+  var sql = [
+    "alter table cash_out_actions add device_id text not null default ''"
+  ]
+  db.multi(sql, next)
+}
+
+exports.down = function (next) {
+  next()
+}


### PR DESCRIPTION
If a costumer originates a cashOut transaction at one device, and then
redeem at a different device, the wrong machine would have bills debited from it.

With device_id being saved at the cash_out_actions table the bills can
be properly reconciled.

**Note**: Possibly incomplete, see more on trello card.