### PR TITLE
Fixed bitstamp coin scaling

### DIFF
--- a/lib/coin-utils.js
+++ b/lib/coin-utils.js
@@ -61,7 +61,7 @@ const CRYPTO_CURRENCIES = [
   }
 ]
 
-module.exports = {buildUrl, cryptoDir, blockchainDir, configPath, cryptoCurrencies, getCryptoCurrency}
+module.exports = {buildUrl, cryptoDir, blockchainDir, configPath, cryptoCurrencies, getCryptoCurrency, toUnit}
 
 function getCryptoCurrency (cryptoCode) {
   const cryptoCurrency = _.find(['cryptoCode', cryptoCode], CRYPTO_CURRENCIES)
@@ -97,3 +97,10 @@ function cryptoDir (cryptoRec) {
 function configPath (cryptoRec) {
   return path.resolve(cryptoDir(cryptoRec), cryptoRec.configFile)
 }
+
+function toUnit (cryptoAtoms, cryptoCode) {
+  const cryptoRec = getCryptoCurrency(cryptoCode)
+  const unitScale = cryptoRec.unitScale
+  return cryptoAtoms.shift(-unitScale)
+}
+

--- a/lib/plugins/common/kraken.js
+++ b/lib/plugins/common/kraken.js
@@ -1,5 +1,3 @@
-const coinUtils = require('../../coin-utils')
-
 const PAIRS = {
   BTC: {
     USD: 'XXBTZUSD',
@@ -27,10 +25,4 @@ const PAIRS = {
   }
 }
 
-module.exports = {PAIRS, toUnit}
-
-function toUnit (cryptoAtoms, cryptoCode) {
-  const cryptoRec = coinUtils.getCryptoCurrency(cryptoCode)
-  const unitScale = cryptoRec.unitScale
-  return cryptoAtoms.shift(-unitScale)
-}
+module.exports = {PAIRS}

--- a/lib/plugins/exchange/bitstamp/bitstamp.js
+++ b/lib/plugins/exchange/bitstamp/bitstamp.js
@@ -1,6 +1,5 @@
 const common = require('../../common/bitstamp')
-
-const SATOSHI_SHIFT = 8
+const coinUtils = require('../../../coin-utils')
 
 function buy (account, cryptoAtoms, fiatCode, cryptoCode) {
   return trade('buy', account, cryptoAtoms, fiatCode, cryptoCode)
@@ -27,7 +26,7 @@ function trade (type, account, cryptoAtoms, _fiatCode, cryptoCode) {
 
   try {
     const market = common.buildMarket(fiatCode, cryptoCode)
-    const options = {amount: cryptoAtoms.shift(-SATOSHI_SHIFT).toFixed(8)}
+    const options = {amount: coinUtils.toUnit(cryptoAtoms, cryptoCode).toFixed(8)}
 
     return common.authRequest(account, '/' + type + '/market/' + market, options)
       .catch(e => {

--- a/lib/plugins/exchange/kraken/kraken.js
+++ b/lib/plugins/exchange/kraken/kraken.js
@@ -3,6 +3,7 @@ const Kraken = require('kraken-api')
 const _ = require('lodash/fp')
 
 const common = require('../../common/kraken')
+const coinUtils = require('../../../coin-utils')
 
 var PAIRS = common.PAIRS
 
@@ -18,7 +19,7 @@ function sell (account, cryptoAtoms, fiatCode, cryptoCode) {
 
 function trade (account, type, cryptoAtoms, fiatCode, cryptoCode) {
   const kraken = new Kraken(account.apiKey, account.privateKey, {timeout: 30000})
-  const amount = common.toUnit(cryptoAtoms, cryptoCode)
+  const amount = coinUtils.toUnit(cryptoAtoms, cryptoCode)
   const amountStr = amount.toFixed(6)
 
   const pair = _.includes(fiatCode, ['USD', 'EUR'])


### PR DESCRIPTION
The coin scaling for the bistamp excahnge was using a satoshi scaling for ETH when it should have been using wei.