### PR TITLE
Patch bitcoind-inhereted network vulnerability

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -21,28 +21,28 @@ module.exports = {
 
 const BINARIES = {
   BTC: {
-    url: 'https://bitcoin.org/bin/bitcoin-core-0.16.2/bitcoin-0.16.2-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-0.16.2/bin'
+    url: 'https://bitcoin.org/bin/bitcoin-core-0.16.3/bitcoin-0.16.3-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-0.16.3/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.13-225171a4.tar.gz',
-    dir: 'geth-linux-amd64-1.8.13-225171a4'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.15-89451f7c.tar.gz',
+    dir: 'geth-linux-amd64-1.8.15-89451f7c'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-2.0.0-linux64.tar.gz',
     dir: 'zcash-2.0.0/bin'
   },
   DASH: {
-    url: 'https://github.com/dashpay/dash/releases/download/v0.12.3.2/dashcore-0.12.3.2-x86_64-linux-gnu.tar.gz',
+    url: 'https://github.com/dashpay/dash/releases/download/v0.12.3.3/dashcore-0.12.3.3-x86_64-linux-gnu.tar.gz',
     dir: 'dashcore-0.12.3/bin'
   },
   LTC: {
-    url: 'https://download.litecoin.org/litecoin-0.16.0/linux/litecoin-0.16.0-x86_64-linux-gnu.tar.gz',
-    dir: 'litecoin-0.16.0/bin'
+    url: 'https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz',
+    dir: 'litecoin-0.16.3/bin'
   },
   BCH: {
-    url: 'https://download.bitcoinabc.org/0.18.0/linux/bitcoin-abc-0.18.0-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-abc-0.18.0/bin',
+    url: 'https://download.bitcoinabc.org/0.18.2/linux/bitcoin-abc-0.18.2-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-abc-0.18.2/bin',
     files: [['bitcoind', 'bitcoincashd'], ['bitcoin-cli', 'bitcoincash-cli']]
   }
 }


### PR DESCRIPTION
Updates BTC, BCH, LTC, DASH for CVE-2018-17144.

Updates ETH to latest.