### PR TITLE
Change Infura credential fieldType

### DIFF
--- a/schemas/infura.json
+++ b/schemas/infura.json
@@ -5,7 +5,7 @@
     {
       "code": "apiKey",
       "display": "API key",
-      "fieldType": "password",
+      "fieldType": "string",
       "secret": true,
       "required": true,
       "value": ""
@@ -21,7 +21,7 @@
     {
       "code": "endpoint",
       "display": "Endpoint",
-      "fieldType": "password",
+      "fieldType": "string",
       "secret": true,
       "required": true,
       "value": ""


### PR DESCRIPTION
API key and endpoint are less sensistive, and leaving these two displayed would allow accidental typos, such extraneous spaces, to be caught.