### PR TITLE
Disable motd scripts

### DIFF
--- a/bin/lamassu-update
+++ b/bin/lamassu-update
@@ -62,12 +62,23 @@ perl -i -pe 's/command=.*/command=$ENV{NPM_BIN}\/lamassu-admin-server/g' /etc/su
 decho "updating lamassu-server"
 supervisorctl update lamassu-server >> ${LOG_FILE} 2>&1
 supervisorctl update lamassu-admin-server >> ${LOG_FILE} 2>&1
+supervisorctl start lamassu-server >> ${LOG_FILE} 2>&1
+supervisorctl start lamassu-admin-server >> ${LOG_FILE} 2>&1
 
 decho "updating backups conf"
 BACKUP_CMD=${NPM_BIN}/lamassu-backup-pg
 BACKUP_CRON="@daily $BACKUP_CMD > /dev/null"
 ( (crontab -l 2>/dev/null || echo -n "") | grep -v '@daily.*lamassu-backup-pg'; echo $BACKUP_CRON ) | crontab - >> $LOG_FILE 2>&1
 $BACKUP_CMD >> $LOG_FILE 2>&1
+
+decho "updating motd scripts
+set +e
+chmod -x /etc/update-motd.d/*-release-upgrade     
+chmod -x /etc/update-motd.d/*-updates-available
+chmod -x /etc/update-motd.d/*-reboot-required
+chmod -x /etc/update-motd.d/*-help-text
+chmod -x /etc/update-motd.d/*-cloudguest
+set -e
 
 # reset terminal to link new executables
 hash -r


### PR DESCRIPTION
Disable post-SSH logon prompts to take upgrade actions which could break the server.

Includes change from https://github.com/lamassu/lamassu-server/pull/175.