### PR TITLE
Prune Dash

### DIFF
--- a/lib/blockchain/dash.js
+++ b/lib/blockchain/dash.js
@@ -20,5 +20,8 @@ function buildConfig () {
   return `rpcuser=lamassuserver
 rpcpassword=${common.randomPass()}
 dbcache=500
-keypool=10000`
+keypool=10000
+litemode=1
+prune=4000
+txindex=0`
 }


### PR DESCRIPTION
Keep the Dash blockchain pruned (4.7G).