### PR TITLE
Adjust mock-ticker rates, add warning

### DIFF
--- a/lib/admin/config.js
+++ b/lib/admin/config.js
@@ -173,7 +173,7 @@ function fetchData () {
         {code: 'bitstamp', display: 'Bitstamp', class: 'ticker', cryptos: ['BTC', 'ETH', 'LTC', 'BCH']},
         {code: 'coinbase', display: 'Coinbase', class: 'ticker', cryptos: ['BTC', 'ETH', 'LTC', 'BCH']},
         {code: 'quadrigacx', display: 'QuadrigaCX', class: 'ticker', cryptos: ['BTC', 'ETH', 'LTC', 'BCH']},
-        {code: 'mock-ticker', display: 'Mock ticker', class: 'ticker', cryptos: ALL_CRYPTOS},
+        {code: 'mock-ticker', display: 'Mock (Caution!)', class: 'ticker', cryptos: ALL_CRYPTOS},
         {code: 'bitcoind', display: 'bitcoind', class: 'wallet', cryptos: ['BTC']},
         {code: 'no-layer2', display: 'No Layer 2', class: 'layer2', cryptos: ALL_CRYPTOS},
         {code: 'infura', display: 'Infura', class: 'wallet', cryptos: ['ETH']},

--- a/lib/plugins/ticker/mock-ticker/mock-ticker.js
+++ b/lib/plugins/ticker/mock-ticker/mock-ticker.js
@@ -3,8 +3,8 @@ const BN = require('../../../bn')
 function ticker (account, fiatCode, cryptoCode) {
   return Promise.resolve({
     rates: {
-      ask: BN(105),
-      bid: BN(100)
+      ask: BN(20000),
+      bid: BN(1000)
     }
   })
 }

--- a/lib/plugins/ticker/mock-ticker/mock-ticker.js
+++ b/lib/plugins/ticker/mock-ticker/mock-ticker.js
@@ -4,7 +4,7 @@ function ticker (account, fiatCode, cryptoCode) {
   return Promise.resolve({
     rates: {
       ask: BN(20000),
-      bid: BN(1000)
+      bid: BN(100)
     }
   })
 }


### PR DESCRIPTION
In case of accidental use in production, use more favourable rates and add a warning in the admin.