### PR TITLE
Add optional repository identifier argument to lamassu-update

### DIFF
--- a/bin/lamassu-update
+++ b/bin/lamassu-update
@@ -3,10 +3,19 @@ set -e
 
 export LOG_FILE=/tmp/update.$(date +"%Y%m%d").log
 export NPM_BIN=$(npm -g bin)
+export SERVER_ROOT=$(npm -g root)/lamassu-server
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+IDENTIFIER=$1
 
-rm -f ${LOG_FILE}
+if [ -n $IDENTIFIER ]; then
+  trap 'echo Invalid repository identifier: $IDENTIFIER' ERR
+  npm install --silent --dry-run $IDENTIFIER > /dev/null 2>&1
+  trap - ERR
+else
+  IDENTIFIER="lamassu/lamassu-server#dev"
+fi
+
+rm -f ${LOG_FILE} > /dev/null 2>&1
 
 decho () {
   echo `date +"%H:%M:%S"` $1
@@ -35,22 +44,25 @@ supervisorctl stop lamassu-admin-server >> ${LOG_FILE} 2>&1
 decho "unlinking ${NPM_BIN}/lamassu* old executables"
 find ${NPM_BIN} -type l \( -name "lamassu-*" -or -name "hkdf" \) -exec rm -fv {} \; >> ${LOG_FILE} 2>&1
 
-if [ -d "/usr/lib/node_modules/lamassu-server" ]; then
-    decho "renaming old lamassu-server instance to lamassu-server-old"
-    mv -v "/usr/lib/node_modules/lamassu-server" "/usr/lib/node_modules/lamassu-server-old" >> ${LOG_FILE} 2>&1
+if [ -d "${SERVER_ROOT}" ]; then
+  if [ -d "${SERVER_ROOT}-old" ]; then
+    decho "deleting prior lamassu-server-old"
+    rm -rf ${SERVER_ROOT}-old >> ${LOG_FILE} 2>&1
+  fi
+  decho "renaming old lamassu-server instance to lamassu-server-old"
+  mv -v "${SERVER_ROOT}" "${SERVER_ROOT}-old" >> ${LOG_FILE} 2>&1
 fi
 
 decho "updating node"
 npm install n -g >> ${LOG_FILE} 2>&1
 n lts >> ${LOG_FILE} 2>&1
 decho "version installed $(node -v)"
-export NPM_BIN=$(npm -g bin)
 
-decho "updating lamassu-server#dev"
-npm -g install lamassu/lamassu-server#dev --unsafe-perm >> ${LOG_FILE} 2>&1
+decho "updating $IDENTIFIER"
+npm -g install $IDENTIFIER --unsafe-perm >> ${LOG_FILE} 2>&1
 
 decho "rebuilding npm deps"
-cd $(npm root -g)/lamassu-server/ >> ${LOG_FILE} 2>&1
+cd ${SERVER_ROOT}/ >> ${LOG_FILE} 2>&1
 npm rebuild >> ${LOG_FILE} 2>&1
 
 decho "running migration"
@@ -58,7 +70,7 @@ lamassu-migrate >> ${LOG_FILE} 2>&1
 lamassu-migrate-config >> ${LOG_FILE} 2>&1
 
 decho "update to mnemonic"
-$SCRIPTPATH/bin/lamassu-update-to-mnemonic --prod
+${SERVER_ROOT}/bin/lamassu-update-to-mnemonic --prod
 
 decho "updating supervisor conf"
 perl -i -pe 's/command=.*/command=$ENV{NPM_BIN}\/lamassu-server/g' /etc/supervisor/conf.d/lamassu-server.conf >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
Also since lamassu-update-to-mnemonic isn't put in the `node_modules/bin` folder, `$SCRIPTPATH` doesn't help get you there, so I use `SERVER_ROOT` instead. 

Would it maybe be better to have the repository identifier as an environment variable? Read from the lamassu.json?