### PR TITLE
migrate-options unit test added

### DIFF
--- a/lib/migrate-options.js
+++ b/lib/migrate-options.js
@@ -13,7 +13,7 @@ const paths = _.wrap(_.split, path.sep)
 // /usr/lib/node_modules/lamassu-server/certs/Lamassu_OP.pem => 3
 const indexOfLs = _.flow(paths, _.wrap(_.indexOf, 'lamassu-server'))
 
-module.exports = {run, mapKeyValuesDeep}
+module.exports = {run, mapKeyValuesDeep, updateOptionBasepath}
 
 function mapKeyValuesDeep (cb, obj, key) {
   if (_.isArray(obj)) {
@@ -22,6 +22,32 @@ function mapKeyValuesDeep (cb, obj, key) {
     return _.pickBy((val, key) => mapKeyValuesDeep(cb, val, key), obj)
   } else {
     return cb(obj, key)
+  }
+}
+
+function updateOptionBasepath (result, optionName) {
+  const currentPath = _.get(optionName, result)
+
+  // process only keys that contains
+  // lamassu-server dir in its path
+  const i = indexOfLs(currentPath)
+  if (i === -1) {
+    return
+  }
+
+  // workout the relative path
+  // /usr/lib/node_modules/lamassu-server/certs/Lamassu_OP.pem => certs/Lamassu_OP.pem
+  const rPath = _.drop(i + 1, paths(currentPath))
+
+  // prepend the current lamassu-server path
+  // certs/Lamassu_OP.pem => /usr/local/lib/node_modules/lamassu-server/certs/Lamassu_OP.pem
+  const newPath = _.join(path.sep, _.concat([currentBasePath], rPath))
+
+  // update this option
+  // if the value has changed
+  if (!_.isEqual(currentPath, newPath)) {
+    console.log(`Migrating option ${optionName} to new path ${newPath}`)
+    result[optionName] = newPath
   }
 }
 
@@ -39,31 +65,14 @@ async function run () {
   // get all the options
   // that ends with "Path" suffix
   console.log(`Detected lamassu-server basepath: ${currentBasePath}`)
-  _.map(optionName => {
-    const currentPath = _.get(optionName, result)
-
-    // process only keys that contains
-    // lamassu-server dir in its path
-    const i = indexOfLs(currentPath)
-    if (i === -1) {
-      return
-    }
-
-    // workout the relative path
-    // /usr/lib/node_modules/lamassu-server/certs/Lamassu_OP.pem => certs/Lamassu_OP.pem
-    const rPath = _.drop(i + 1, paths(currentPath))
-
-    // prepend the current lamassu-server path
-    // certs/Lamassu_OP.pem => /usr/local/lib/node_modules/lamassu-server/certs/Lamassu_OP.pem
-    const newPath = _.join(path.sep, _.concat([currentBasePath], rPath))
-
-    // update this option
-    // if the value has changed
-    if (!_.isEqual(currentPath, newPath)) {
-      console.log(`Migrating option ${optionName} to new path ${newPath}`)
-      result[optionName] = newPath
-    }
-  }, ['seedPath', 'caPath', 'certPath', 'keyPath', 'lamassuCaPath'])
+  _.each(_.wrap(updateOptionBasepath, result),
+    [
+      'seedPath',
+      'caPath',
+      'certPath',
+      'keyPath',
+      'lamassuCaPath'
+    ])
 
   const shouldMigrate = !_.isEqual(result, currentOpts) || _.has('lamassuServerPath', result)
 

--- a/test/unit/migrate-options.js
+++ b/test/unit/migrate-options.js
@@ -1,7 +1,10 @@
 import test from 'ava'
 import _ from 'lodash/fp'
+import path from 'path'
 
-import {mapKeyValuesDeep} from '../../lib/migrate-options'
+import {mapKeyValuesDeep, updateOptionBasepath} from '../../lib/migrate-options'
+
+const currentBasePath = path.dirname(path.dirname(__dirname))
 
 test('mapKeyValuesDeep', t => {
   const test = {
@@ -30,6 +33,32 @@ test('mapKeyValuesDeep', t => {
   mapKeyValuesDeep((v, k) => {
     result.push(_.fromPairs([[k, v]]))
   }, test)
+
+  t.deepEqual(result, expected)
+})
+
+test('updateOptionBasepath', t => {
+  const test = {
+    someBooleanOption: true,
+    someStringOption: 'my-custom-option',
+    customExternalPath: '/usr/lib/node_modules/ava',
+    seedPath: '/etc/lamassu/seeds/seed.txt',
+    caPath: '/usr/lib/node_modules/lamassu-server/certs/Lamassu_OP_Root_CA.pem'
+  }
+  const expected = {
+    someBooleanOption: true,
+    someStringOption: 'my-custom-option',
+    customExternalPath: '/usr/lib/node_modules/ava',
+    seedPath: '/etc/lamassu/seeds/seed.txt',
+    caPath: path.join(currentBasePath, 'certs/Lamassu_OP_Root_CA.pem')
+  }
+
+  let result = _.clone(test)
+
+  _.each(
+    _.wrap(updateOptionBasepath, result),
+    _.keys(test)
+  )
 
   t.deepEqual(result, expected)
 })


### PR DESCRIPTION
I took out the updateOptionBasepath function and added a unit test.
I'll port the same on master