### PR TITLE
Allow the domain to be configurable when generating developer certificates

### DIFF
--- a/bin/cert-gen.sh
+++ b/bin/cert-gen.sh
@@ -3,6 +3,7 @@
 set -e
 
 DOMAIN=localhost
+[ ! -z "$1" ] && DOMAIN=$1
 
 CONFIG_DIR=$HOME/.lamassu
 LOG_FILE=/tmp/cert-gen.log


### PR DESCRIPTION
The intended domain/IP can be provided as an argument to the bash script.
Example: `$ bash bin/cert-gen.sh 192.168.1.1`

The lack of such argument will default to the previous value: `localhost`.