### PR TITLE
Fix lamassu-ofac-update-sources during update

### DIFF
--- a/bin/lamassu-update
+++ b/bin/lamassu-update
@@ -56,7 +56,7 @@ lamassu-migrate >> ${LOG_FILE} 2>&1
 lamassu-migrate-config >> ${LOG_FILE} 2>&1
 
 decho "update ofac sources"
-$SCRIPTPATH/bin/lamassu-ofac-update-sources
+lamassu-ofac-update-sources >> ${LOG_FILE} 2>&1
 
 decho "updating supervisor conf"
 perl -i -pe 's/command=.*/command=$ENV{NPM_BIN}\/lamassu-server/g' /etc/supervisor/conf.d/lamassu-server.conf >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
Otherwise:
```
bash: line 59: /bin/lamassu-ofac-update-sources: No such file or directory
```