### PR TITLE
Fix cash-out exchange behavior for 'rejected' tx

### DIFF
--- a/lib/cash-out/cash-out-atomic.js
+++ b/lib/cash-out/cash-out-atomic.js
@@ -119,10 +119,10 @@ function updateCassettes (t, tx) {
 }
 
 function wasJustAuthorized (oldTx, newTx, isZeroConf) {
-  const isAuthorized = () => _.includes(oldTx.status, ['notSeen', 'published']) &&
+  const isAuthorized = () => _.includes(oldTx.status, ['notSeen', 'published', 'rejected']) &&
     _.includes(newTx.status, ['authorized', 'instant', 'confirmed'])
 
-  const isConfirmed = () => _.includes(oldTx.status, ['notSeen', 'published', 'authorized']) &&
+  const isConfirmed = () => _.includes(oldTx.status, ['notSeen', 'published', 'authorized', 'rejected']) &&
     _.includes(newTx.status, ['instant', 'confirmed'])
 
   return isZeroConf ? isAuthorized() : isConfirmed()


### PR DESCRIPTION
A TX on the 'rejected' state should still be watched for authorization.

This fixes the bug where delayed cash-out confirmations would not
trigger a exchange sell command.