### PR TITLE
Add lamassu-coinatmradar, lamassu-devices, lamassu-operator

### DIFF
--- a/bin/lamassu-coinatmradar
+++ b/bin/lamassu-coinatmradar
@@ -5,7 +5,7 @@ SEED="$(cat ~/seeds/seed.txt)"
 echo
 echo "Here is the 'External ID' of your paired machine(s), for use under the 'ATM / Teller details' of your CoinATMRadar listing:"
 echo
-paste <(su - postgres -c "psql \"lamassu\" -Atc \"select device_id from devices\"" | cut -c -32) <(su - postgres -c "psql \"lamassu\" -Atc \"select name from devices\"") | column -s $'\t' -t
+su - postgres -c "psql \"lamassu\" -Atc \"select regexp_replace(left(device_id,32), '$', ' '),regexp_replace(name, '^', ' ') from devices\""
 echo
 echo "If communicating with CoinATMRadar, it may be helpful to relay your 'Operator ID':"
 echo

--- a/bin/lamassu-coinatmradar
+++ b/bin/lamassu-coinatmradar
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+SEED="$(cat ~/seeds/seed.txt)"
+
+echo
+echo "Here is the 'External ID' of your paired machine(s), for use under the 'ATM / Teller details' of your CoinATMRadar listing:"
+echo
+paste <(su - postgres -c "psql \"lamassu\" -Atc \"select device_id from devices\"" | cut -c -32) <(su - postgres -c "psql \"lamassu\" -Atc \"select name from devices\"") | column -s $'\t' -t
+echo
+echo "If communicating with CoinATMRadar, it may be helpful to relay your 'Operator ID':"
+echo
+/usr/bin/hkdf operator-id "$SEED" | cut -c -32
+echo

--- a/bin/lamassu-devices
+++ b/bin/lamassu-devices
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo
+echo "Your list of paired machines and their Device IDs and names:"
+echo
+su - postgres -c "psql \"lamassu\" -Atc \"select device_id, name from devices\""
+echo

--- a/bin/lamassu-operator
+++ b/bin/lamassu-operator
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SEED="$cat ~/seeds/seed.txt"
+
+echo
+echo "Your Operator ID for use with CoinATMRadar is:" 
+echo
+/usr/bin/hkdf operator-id '$SEED' | cut -c -32
+echo

--- a/bin/lamassu-operator
+++ b/bin/lamassu-operator
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-SEED="$cat ~/seeds/seed.txt"
+SEED="$(cat ~/seeds/seed.txt)"
 
 echo
 echo "Your Operator ID for use with CoinATMRadar is:" 
 echo
-/usr/bin/hkdf operator-id '$SEED' | cut -c -32
+/usr/bin/hkdf operator-id "$SEED" | cut -c -32
 echo

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "lamassu-send-coins": "./bin/lamassu-send-coins",
     "lamassu-ofac-update-sources": "./bin/lamassu-ofac-update-sources",
     "lamassu-devices": "./bin/lamassu-devices",
-    "lamassu-operator": "./bin/lamassu-operator"
+    "lamassu-operator": "./bin/lamassu-operator",
+    "lamassu-coinatmradar": "./bin/lamassu-coinatmradar"
   },
   "scripts": {
     "start": "node bin/lamassu-server",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
     "lamassu-update": "./bin/lamassu-update",
     "lamassu-ofac-update": "./bin/lamassu-ofac-update",
     "lamassu-send-coins": "./bin/lamassu-send-coins",
-    "lamassu-ofac-update-sources": "./bin/lamassu-ofac-update-sources"
+    "lamassu-ofac-update-sources": "./bin/lamassu-ofac-update-sources",
+    "lamassu-devices": "./bin/lamassu-devices",
+    "lamassu-operator": "./bin/lamassu-operator"
   },
   "scripts": {
     "start": "node bin/lamassu-server",


### PR DESCRIPTION
For use when relaying device_ids for remote updates, and retrieving the operator ID used with CoinATMRadar.