### PR TITLE
Update lamassu-coinatmradar for 64 characters

### DIFF
--- a/bin/lamassu-coinatmradar
+++ b/bin/lamassu-coinatmradar
@@ -5,9 +5,9 @@ SEED="$(cat ~/seeds/seed.txt)"
 echo
 echo "Here is the 'External ID' of your paired machine(s), for use under the 'ATM / Teller details' of your CoinATMRadar listing:"
 echo
-su - postgres -c "psql \"lamassu\" -Atc \"select regexp_replace(left(device_id,32), '$', ' '),regexp_replace(name, '^', ' ') from devices\""
+su - postgres -c "psql \"lamassu\" -Atc \"select regexp_replace(device_id, '$', ' '),regexp_replace(name, '^', ' ') from devices\""
 echo
-echo "If communicating with CoinATMRadar, it may be helpful to relay your 'Operator ID':"
+echo "If speaking with CoinATMRadar directly, it may be helpful to let them know your 'Operator ID':"
 echo
-/usr/bin/hkdf operator-id "$SEED" | cut -c -32
+/usr/bin/hkdf operator-id "$SEED"
 echo


### PR DESCRIPTION
We're passing 64-characters to the CAR API, instead of 32.