### PR TITLE
Trim API token's whitespace

### DIFF
--- a/lib/plugins/wallet/bitgo/bitgo.js
+++ b/lib/plugins/wallet/bitgo/bitgo.js
@@ -15,7 +15,7 @@ const SUPPORTED_COINS = ['BTC', 'ZEC', 'LTC', 'BCH', 'DASH']
 
 function buildBitgo (account) {
   const env = account.environment === 'test' ? 'test' : 'prod'
-  return new BitGo.BitGo({ accessToken: account.token, env, userAgent: userAgent })
+  return new BitGo.BitGo({ accessToken: account.token.trim(), env, userAgent: userAgent })
 }
 
 function getWallet (account, cryptoCode) {


### PR DESCRIPTION
BitGo's site adds an extraneous space to the API token when copy/pasting to the admin field, causing requests to fail.

Trim whitespace before using. Temporary fix until we have credential field validation in the new admin.