### PR TITLE
bitcoind 0.17/0.18 getbalance compatibility change

### DIFF
--- a/lib/plugins/wallet/bitcoind/bitcoind.js
+++ b/lib/plugins/wallet/bitcoind/bitcoind.js
@@ -27,7 +27,7 @@ function checkCryptoCode (cryptoCode) {
 
 function accountBalance (account, cryptoCode, confirmations) {
   return checkCryptoCode(cryptoCode)
-    .then(() => fetch('getbalance', ['', confirmations]))
+    .then(() => fetch('getbalance', ['*', confirmations]))
     .then(r => BN(r).shift(unitScale).round())
 }
 


### PR DESCRIPTION
Because of bitcoind deprecating its internal account system, the getbalance RPC call now has a dummy argument as the first argument. The help says it can be omitted or changed to '*', so we change it to '*', both for backward compatibility and because in testing I found that omitting the argument was broken. Using '*' has the same semantics as omitting the argument, if accounts were not used in the previous version of bitcoind.