### PR TITLE
fix: downgrade BTC, BCH, LTC daemons

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -21,8 +21,8 @@ module.exports = {
 
 const BINARIES = {
   BTC: {
-    url: 'https://bitcoin.org/bin/bitcoin-core-0.19.0.1/bitcoin-0.19.0.1-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-0.19.0.1/bin'
+    url: 'https://bitcoin.org/bin/bitcoin-core-0.16.3/bitcoin-0.16.3-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-0.16.3/bin'
   },
   ETH: {
     url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.9-01744997.tar.gz',
@@ -37,12 +37,12 @@ const BINARIES = {
     dir: 'dashcore-0.14.0/bin'
   },
   LTC: {
-    url: 'https://download.litecoin.org/litecoin-0.17.1/linux/litecoin-0.17.1-x86_64-linux-gnu.tar.gz',
-    dir: 'litecoin-0.17.1/bin'
+    url: 'https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz',
+    dir: 'litecoin-0.16.3/bin'
   },
   BCH: {
-    url: 'https://download.bitcoinabc.org/0.20.9/linux/bitcoin-abc-0.20.9-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-abc-0.20.9/bin',
+    url: 'https://download.bitcoinabc.org/0.20.5/linux/bitcoin-abc-0.20.5-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-abc-0.20.5/bin',
     files: [['bitcoind', 'bitcoincashd'], ['bitcoin-cli', 'bitcoincash-cli']]
   }
 }


### PR DESCRIPTION
BTC & LTC 0.17 and above change the account RPC such that unconfirmed deposits are not seen until confirmed. This happens on BCH 0.20.6 and above as well. Remain on older releases until new RPC calls are accounted for.