### PR TITLE
feat: add receipt printing page

### DIFF
--- a/new-lamassu-admin/package-lock.json
+++ b/new-lamassu-admin/package-lock.json
@@ -14921,6 +14921,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.7.44",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.44.tgz",
+      "integrity": "sha512-y5qiJTjKfU8gRdyhFodp2TsC/TH4YQwspz2nDMNyWENNKTAQMZ8/C7eo7zltnoXPk2f1OGOw0IwsI+TeRI/nVg==",
+      "requires": {
+        "minimist": "^1.2.0",
+        "xml2js": "^0.4.17"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -15963,8 +15972,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
       "version": "3.1.1",
@@ -22690,8 +22698,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",
@@ -26336,6 +26343,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/new-lamassu-admin/package.json
+++ b/new-lamassu-admin/package.json
@@ -17,6 +17,7 @@
     "fuse.js": "^3.4.6",
     "graphql": "^14.5.8",
     "jss-plugin-extend": "^10.0.0",
+    "libphonenumber-js": "^1.7.44",
     "moment": "2.24.0",
     "qrcode.react": "0.9.3",
     "ramda": "^0.26.1",

--- a/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
+++ b/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
@@ -31,6 +31,7 @@ const BooleanPropertiesTable = memo(
     }
 
     const innerCancel = () => {
+      setRadioGroupValues(elements)
       setEditing(false)
     }
 
@@ -80,8 +81,10 @@ const BooleanPropertiesTable = memo(
             {radioGroupValues &&
               radioGroupValues.map((element, idx) => (
                 <TableRow key={idx} size="sm" className={classes.tableRow}>
-                  <TableCell className={classes.tableCell}>
+                  <TableCell className={classes.leftTableCell}>
                     {element.display}
+                  </TableCell>
+                  <TableCell className={classes.rightTableCell}>
                     {editing ? (
                       <RadioGroup
                         options={radioButtonOptions}

--- a/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
+++ b/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
@@ -46,8 +46,8 @@ const BooleanPropertiesTable = memo(
     }
 
     const radioButtonOptions = [
-      { label: 'Yes', value: true },
-      { label: 'No', value: false }
+      { display: 'Yes', value: true },
+      { display: 'No', value: false }
     ]
 
     if (!elements || radioGroupValues?.length === 0) return null

--- a/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.styles.js
+++ b/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.styles.js
@@ -1,5 +1,5 @@
 import baseStyles from 'src/pages/Logs.styles'
-import { tableCellColor, zircon } from 'src/styling/variables'
+import { backgroundColor, zircon } from 'src/styling/variables'
 
 const { fillColumn } = baseStyles
 
@@ -14,20 +14,28 @@ const booleanPropertiesTableStyles = {
     alignItems: 'center',
     justifyContent: 'space-between',
     '&:nth-child(even)': {
-      backgroundColor: tableCellColor
+      backgroundColor: backgroundColor
     },
     '&:nth-child(odd)': {
       backgroundColor: zircon
     },
+    minHeight: 32,
+    height: 'auto',
+    padding: [[8, 16, 8, 24]],
     boxShadow: '0 0 0 0 rgba(0, 0, 0, 0)'
   },
-  tableCell: {
+  leftTableCell: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    width: '100%',
-    height: 32,
-    padding: [[5, 14, 5, 20]]
+    justifyContent: 'left',
+    width: 200,
+    padding: [0]
+  },
+  rightTableCell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'right',
+    padding: [0]
   },
   transparentButton: {
     '& > *': {
@@ -53,7 +61,7 @@ const booleanPropertiesTableStyles = {
   radioButtons: {
     display: 'flex',
     flexDirection: 'row',
-    marginRight: -15
+    margin: [-15]
   },
   rightLink: {
     marginLeft: '20px'

--- a/new-lamassu-admin/src/components/editableProperty/EditableProperty.js
+++ b/new-lamassu-admin/src/components/editableProperty/EditableProperty.js
@@ -1,0 +1,80 @@
+import { makeStyles } from '@material-ui/core/styles'
+import React, { useState, memo } from 'react'
+
+import { H4, P } from 'src/components/typography'
+import { Link } from 'src/components/buttons'
+import { RadioGroup } from 'src/components/inputs'
+import { ReactComponent as EditIcon } from 'src/styling/icons/action/edit/enabled.svg'
+import { ReactComponent as EditIconDisabled } from 'src/styling/icons/action/edit/disabled.svg'
+
+import { editablePropertyStyles } from './EditableProperty.styles'
+
+const useStyles = makeStyles(editablePropertyStyles)
+
+const EditableProperty = memo(
+  ({ title, prefixText, disabled, options, value, save }) => {
+    const [editing, setEditing] = useState(false)
+    const [currentValue, setCurrentValue] = useState(value)
+
+    const classes = useStyles()
+
+    const innerSave = () => {
+      save(currentValue)
+      setEditing(false)
+    }
+
+    const innerCancel = () => setEditing(false)
+
+    // TODO: can do this or just pass the options with the right properties... which's better?
+    const radioButtonOptions = options.map(it => ({
+      label: it.display,
+      value: it.value
+    }))
+
+    return (
+      <>
+        <div className={classes.rowWrapper}>
+          <H4>{title}</H4>
+          {editing ? (
+            <div className={classes.leftSpace}>
+              <Link
+                className={classes.leftSpace}
+                onClick={innerCancel}
+                color="secondary">
+                Cancel
+              </Link>
+              <Link
+                className={classes.leftSpace}
+                onClick={innerSave}
+                color="primary">
+                Save
+              </Link>
+            </div>
+          ) : (
+            <div className={classes.transparentButton}>
+              <button disabled={disabled} onClick={() => setEditing(true)}>
+                {disabled ? <EditIconDisabled /> : <EditIcon />}
+              </button>
+            </div>
+          )}
+        </div>
+        {editing ? (
+          <RadioGroup
+            options={radioButtonOptions}
+            value={currentValue}
+            onChange={event => setCurrentValue(event.target.value)}
+            className={classes.radioButtons}
+          />
+        ) : (
+          <P>
+            {`${prefixText} ${radioButtonOptions
+              .find(it => it.value === currentValue)
+              .label.toLowerCase()}`}
+          </P>
+        )}
+      </>
+    )
+  }
+)
+
+export default EditableProperty

--- a/new-lamassu-admin/src/components/editableProperty/EditableProperty.js
+++ b/new-lamassu-admin/src/components/editableProperty/EditableProperty.js
@@ -25,12 +25,6 @@ const EditableProperty = memo(
 
     const innerCancel = () => setEditing(false)
 
-    // TODO: can do this or just pass the options with the right properties... which's better?
-    const radioButtonOptions = options.map(it => ({
-      label: it.display,
-      value: it.value
-    }))
-
     return (
       <>
         <div className={classes.rowWrapper}>
@@ -60,16 +54,16 @@ const EditableProperty = memo(
         </div>
         {editing ? (
           <RadioGroup
-            options={radioButtonOptions}
+            options={options}
             value={currentValue}
             onChange={event => setCurrentValue(event.target.value)}
             className={classes.radioButtons}
           />
         ) : (
           <P>
-            {`${prefixText} ${radioButtonOptions
-              .find(it => it.value === currentValue)
-              .label.toLowerCase()}`}
+            {`${prefixText} ${options
+              .find(it => it.display === currentValue)
+              .display.toLowerCase()}`}
           </P>
         )}
       </>

--- a/new-lamassu-admin/src/components/editableProperty/EditableProperty.styles.js
+++ b/new-lamassu-admin/src/components/editableProperty/EditableProperty.styles.js
@@ -1,0 +1,32 @@
+const editablePropertyStyles = {
+  transparentButton: {
+    '& > *': {
+      margin: 'auto 12px'
+    },
+    '& button': {
+      border: 'none',
+      backgroundColor: 'transparent',
+      cursor: 'pointer'
+    }
+  },
+  rowWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+    flex: 'wrap'
+  },
+  rightAligned: {
+    display: 'flex',
+    position: 'absolute',
+    right: 0
+  },
+  radioButtons: {
+    display: 'flex',
+    flexDirection: 'row'
+  },
+  leftSpace: {
+    marginLeft: '20px'
+  }
+}
+
+export { editablePropertyStyles }

--- a/new-lamassu-admin/src/components/editableProperty/index.js
+++ b/new-lamassu-admin/src/components/editableProperty/index.js
@@ -1,0 +1,3 @@
+import EditableProperty from './EditableProperty'
+
+export { EditableProperty }

--- a/new-lamassu-admin/src/components/inputs/base/RadioGroup.js
+++ b/new-lamassu-admin/src/components/inputs/base/RadioGroup.js
@@ -51,9 +51,9 @@ const RadioGroup = ({
           {options.map((option, idx) => (
             <Label
               key={idx}
-              value={option.value}
+              value={option.display}
               control={<GreenRadio />}
-              label={option.label}
+              label={option.display}
             />
           ))}
         </MaterialRadioGroup>

--- a/new-lamassu-admin/src/pages/OperatorInfo/ContactInfo.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/ContactInfo.js
@@ -238,8 +238,8 @@ const ContactInfo = () => {
                 editing={editing}
                 displayValue={displayTextValue}
                 options={[
-                  { label: 'On', value: INFO_CARD_ENABLED },
-                  { label: 'Off', value: INFO_CARD_DISABLED }
+                  { display: 'On', value: INFO_CARD_ENABLED },
+                  { display: 'Off', value: INFO_CARD_DISABLED }
                 ]}
                 className={classes.radioButtons}
                 resetError={() => setError(null)}

--- a/new-lamassu-admin/src/pages/OperatorInfo/OperatorInfo.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/OperatorInfo.js
@@ -8,6 +8,7 @@ import Title from 'src/components/Title'
 import logsStyles from '../Logs.styles'
 
 import CoinAtmRadar from './CoinATMRadar'
+import ReceiptPrinting from './ReceiptPrinting'
 import ContactInfo from './ContactInfo'
 
 const localStyles = {
@@ -50,6 +51,7 @@ const OperatorInfo = () => {
         />
         <div className={classes.contentWrapper}>
           {isSelected(CONTACT_INFORMATION) && <ContactInfo />}
+          {isSelected(RECEIPT) && <ReceiptPrinting />}
           {isSelected(COIN_ATM_RADAR) && <CoinAtmRadar />}
         </div>
       </div>

--- a/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/ReceiptPrinting.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/ReceiptPrinting.js
@@ -1,0 +1,187 @@
+// import { makeStyles } from '@material-ui/core/styles'
+import React, { useState, memo } from 'react'
+import { useQuery, useMutation } from '@apollo/react-hooks'
+import { gql } from 'apollo-boost'
+
+import { EditableProperty } from 'src/components/editableProperty'
+import { BooleanPropertiesTable } from 'src/components/booleanPropertiesTable'
+// import { ActionButton } from 'src/components/buttons'
+// import { ReactComponent as UploadIcon } from 'src/styling/icons/button/upload/zodiac.svg'
+// import { ReactComponent as UploadIconInverse } from 'src/styling/icons/button/upload/white.svg'
+// import { TextInput } from 'src/components/inputs'
+
+// import { mainStyles } from './ReceiptPrinting.styles'
+
+// const useStyles = makeStyles(mainStyles)
+
+const initialValues = {
+  active: 'off',
+  // logo: false,
+  operatorWebsite: false,
+  operatorEmail: false,
+  operatorPhone: false,
+  companyRegistration: false,
+  machineLocation: false,
+  customerNameOrPhoneNumber: false,
+  // commission: false,
+  exchangeRate: false,
+  addressQRCode: false
+  // customText: false,
+  // customTextContent: ''
+}
+
+const GET_CONFIG = gql`
+  {
+    config
+  }
+`
+
+const SAVE_CONFIG = gql`
+  mutation Save($config: JSONObject) {
+    saveConfig(config: $config)
+  }
+`
+
+const receiptPrintingOptions = [
+  {
+    value: 'off',
+    display: 'Off'
+  },
+  {
+    value: 'optional',
+    display: 'Optional (ask user)'
+  },
+  {
+    value: 'on',
+    display: 'On'
+  }
+]
+
+const ReceiptPrinting = memo(() => {
+  const [receiptPrintingConfig, setReceiptPrintingConfig] = useState(null)
+
+  // const classes = useStyles()
+
+  // TODO: treat errors on useMutation and useQuery
+  const [saveConfig] = useMutation(SAVE_CONFIG, {
+    onCompleted: configResponse =>
+      setReceiptPrintingConfig(configResponse.saveConfig.receiptPrinting)
+  })
+  useQuery(GET_CONFIG, {
+    onCompleted: configResponse => {
+      setReceiptPrintingConfig(
+        configResponse?.config?.receiptPrinting ?? initialValues
+      )
+    }
+  })
+
+  const save = it =>
+    saveConfig({ variables: { config: { receiptPrinting: it } } })
+
+  if (!receiptPrintingConfig) return null
+
+  return (
+    <>
+      <EditableProperty
+        title={'Receipt options'}
+        prefixText={'Receipt printing'}
+        disabled={false}
+        options={receiptPrintingOptions}
+        value={receiptPrintingConfig.active}
+        save={it =>
+          saveConfig({
+            variables: { config: { receiptPrinting: { active: it } } }
+          })
+        }
+      />
+      <BooleanPropertiesTable
+        title={'Visible on the receipt (optionals)'}
+        disabled={receiptPrintingConfig.active === 'off'}
+        data={receiptPrintingConfig}
+        elements={[
+          // {
+          //   name: 'logo',
+          //   display: (
+          //     <>
+          //       {'Logo'}
+          //       <ActionButton
+          //         className={classes.actionButton}
+          //         Icon={UploadIcon}
+          //         InverseIcon={UploadIconInverse}
+          //         color={'primary'}
+          //         onClick={() => {
+          //           // TODO: make the replace logo feature
+          //         }}>
+          //         Replace logo
+          //       </ActionButton>
+          //     </>
+          //   ),
+          //   value: receiptPrintingConfig.logo
+          // },
+          {
+            name: 'operatorWebsite',
+            display: 'Operator website',
+            value: receiptPrintingConfig.operatorWebsite
+          },
+          {
+            name: 'operatorEmail',
+            display: 'Operator email',
+            value: receiptPrintingConfig.operatorEmail
+          },
+          {
+            name: 'operatorPhone',
+            display: 'Operator phone',
+            value: receiptPrintingConfig.operatorPhone
+          },
+          {
+            name: 'companyRegistration',
+            display: 'Company registration',
+            value: receiptPrintingConfig.companyRegistration
+          },
+          {
+            name: 'machineLocation',
+            display: 'Machine location',
+            value: receiptPrintingConfig.machineLocation
+          },
+          {
+            name: 'customerNameOrPhoneNumber',
+            display: 'Customer name or phone number (if known)',
+            value: receiptPrintingConfig.customerNameOrPhoneNumber
+          },
+          // {
+          //   name: 'commission',
+          //   display: 'Commission',
+          //   value: receiptPrintingConfig.commission
+          // },
+          {
+            name: 'exchangeRate',
+            display: 'Exchange rate',
+            value: receiptPrintingConfig.exchangeRate
+          },
+          {
+            name: 'addressQRCode',
+            display: 'Address QR code',
+            value: receiptPrintingConfig.addressQRCode
+          }
+          // {
+          //   name: 'customText',
+          //   display: 'Custom text',
+          //   value: receiptPrintingConfig.customText
+          // }
+        ]}
+        save={save}
+      />
+      {/* TODO: textInput should appear only when table is in edit mode, and have it's value saved along with the table values */}
+      {/* <TextInput
+        className={classes.textInput}
+        label={'Custom text content'}
+        multiline
+        rows="4"
+        defaultValue={receiptPrintingConfig.customTextContent}
+      /> */}
+      {/* TODO: add receipt preview on the right side of the page */}
+    </>
+  )
+})
+
+export default ReceiptPrinting

--- a/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/ReceiptPrinting.styles.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/ReceiptPrinting.styles.js
@@ -1,0 +1,11 @@
+const mainStyles = {
+  textInput: {
+    margin: [[28, 20]],
+    width: 304
+  },
+  actionButton: {
+    margin: [[0, 24]]
+  }
+}
+
+export { mainStyles }

--- a/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/index.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/ReceiptPrinting/index.js
@@ -1,0 +1,3 @@
+import ReceiptPrinting from './ReceiptPrinting'
+
+export default ReceiptPrinting

--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,7 +2640,8 @@
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "optional": true
         },
         "bs58": {
           "version": "4.0.1",
@@ -8545,7 +8546,8 @@
         "safe-buffer": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "optional": true
         }
       }
     },
@@ -12728,7 +12730,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",


### PR DESCRIPTION
feat: create an EditableProperty component

feat: added boolean properties table and missing properties

chore: integrated receipt printing page on op info page

fix: fixed style issues in the boolean properties table

feat: added a custom prefixText on the editable property component

chore: commented out currently unused features

fix: fixed boolean properties table color

chore: removed debug logs

fix: boolean properties table cancel button was saving instead of
canceling

fix: receipt printing properties where wrong (customText currently isn't
used, and customerNameOrPhoneNumber was using the wrong property)