### PR TITLE
chore: update DASH, ZEC, ETH nodes; default to PrivateSend on DASH

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -25,16 +25,16 @@ const BINARIES = {
     dir: 'bitcoin-0.16.3/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.9-01744997.tar.gz',
-    dir: 'geth-linux-amd64-1.9.9-01744997'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.11-6a62fe39.tar.gz',
+    dir: 'geth-linux-amd64-1.9.11-6a62fe39'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-2.1.0-1-linux64-debian-jessie.tar.gz',
-    dir: 'zcash-2.1.0-1/bin'
+    url: 'https://z.cash/downloads/zcash-2.1.1-1-linux64-debian-jessie.tar.gz',
+    dir: 'zcash-2.1.1-1/bin'
   },
   DASH: {
-    url: 'https://github.com/dashpay/dash/releases/download/v0.14.0.5/dashcore-0.14.0.5-x86_64-linux-gnu.tar.gz',
-    dir: 'dashcore-0.14.0/bin'
+    url: 'https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-x86_64-linux-gnu.tar.gz',
+    dir: 'dashcore-0.15.0/bin'
   },
   LTC: {
     url: 'https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz',

--- a/lib/blockchain/dash.js
+++ b/lib/blockchain/dash.js
@@ -23,5 +23,7 @@ dbcache=500
 keypool=10000
 litemode=1
 prune=4000
-txindex=0`
+txindex=0
+enableprivatesend=1
+privatesendautostart=1`
 }


### PR DESCRIPTION
Defaults to [PrivateSend](https://github.com/dashpay/dash/blob/v0.15.0.0/doc/release-notes.md#privatesend-improvements) for outgoing (cash-in) transactions, which had been unavailable to pruned (litemode) nodes prior to Dash Core v0.15. Automatically mixes hot wallet funds with little to no observed decrease in availability. Mixing incurs a fee of 0.0001 DASH only once every 10 rounds (currently 0.01 USD).