### PR TITLE
feat: reintroduce lowBalanceMargin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -308,7 +308,7 @@ function plugins (settings, deviceId) {
 
         const rate = rawRate.div(cashInCommission)
 
-        const lowBalanceMargin = BN(1)
+        const lowBalanceMargin = BN(1.03)
 
         const cryptoRec = coinUtils.getCryptoCurrency(cryptoCode)
         const unitScale = cryptoRec.unitScale


### PR DESCRIPTION
We used to employ a low balance margin on our legacy platform, such that we'd consider the wallet balance prematurely low by a certain percentage. This avoided scenarios where a customer attempted a purchase up to the full wallet balance, but which didn't leave enough for bitcoin transaction fees, thus failing to send. Since the transaction fee isn't known until sending, including a buffer largely accounted for this. This adds it back at 3%.