### PR TITLE
chore: update BTC, BCH, LTC, ETH wallets

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -21,12 +21,12 @@ module.exports = {
 
 const BINARIES = {
   BTC: {
-    url: 'https://bitcoin.org/bin/bitcoin-core-0.16.3/bitcoin-0.16.3-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-0.16.3/bin'
+    url: 'https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-0.19.1/bin'
   },
   ETH: {
-    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.11-6a62fe39.tar.gz',
-    dir: 'geth-linux-amd64-1.9.11-6a62fe39'
+    url: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.12-b6f1c8dc.tar.gz',
+    dir: 'geth-linux-amd64-1.9.12-b6f1c8dc'
   },
   ZEC: {
     url: 'https://z.cash/downloads/zcash-2.1.1-1-linux64-debian-jessie.tar.gz',
@@ -37,12 +37,12 @@ const BINARIES = {
     dir: 'dashcore-0.15.0/bin'
   },
   LTC: {
-    url: 'https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz',
-    dir: 'litecoin-0.16.3/bin'
+    url: 'https://download.litecoin.org/litecoin-0.17.1/linux/litecoin-0.17.1-x86_64-linux-gnu.tar.gz',
+    dir: 'litecoin-0.17.1/bin'
   },
   BCH: {
-    url: 'https://download.bitcoinabc.org/0.20.5/linux/bitcoin-abc-0.20.5-x86_64-linux-gnu.tar.gz',
-    dir: 'bitcoin-abc-0.20.5/bin',
+    url: 'https://download.bitcoinabc.org/0.21.2/linux/bitcoin-abc-0.21.2-x86_64-linux-gnu.tar.gz',
+    dir: 'bitcoin-abc-0.21.2/bin',
     files: [['bitcoind', 'bitcoincashd'], ['bitcoin-cli', 'bitcoincash-cli']]
   }
 }


### PR DESCRIPTION
Depends on https://github.com/lamassu/lamassu-server/pull/386.