### PR TITLE
fix: don't assume '+' when using a friendly name with Twilio

### DIFF
--- a/lib/new-admin/config/accounts.js
+++ b/lib/new-admin/config/accounts.js
@@ -1,6 +1,5 @@
 const _ = require('lodash/fp')
 const { COINS, ALL_CRYPTOS } = require('./coins')
-const _ = require('lodash/fp')
 
 const { BTC, BCH, DASH, ETH, LTC, ZEC } = COINS
 

--- a/lib/plugins/sms/twilio/twilio.js
+++ b/lib/plugins/sms/twilio/twilio.js
@@ -14,7 +14,8 @@ function sendMessage (account, rec) {
       const client = twilio(account.accountSid, account.authToken)
       const body = rec.sms.body
       const _toNumber = rec.sms.toNumber || account.toNumber
-      const from = _.startsWith('+')(account.fromNumber)
+      const from = (_.startsWith('+')(account.fromNumber) 
+        || !_.isNumber(String(account.fromNumber).replace(/\s/g,'')))
         ? account.fromNumber : `+${account.fromNumber}`
 
       const opts = {


### PR DESCRIPTION
fix: added missing lodash dependency to accounts lib

fix: don't prepend '+' when using a friendly name with Twilio