### PR TITLE
fix: machine status layout bugs

### DIFF
--- a/new-lamassu-admin/src/components/ConfirmDialog.js
+++ b/new-lamassu-admin/src/components/ConfirmDialog.js
@@ -2,50 +2,50 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   makeStyles
 } from '@material-ui/core'
-import React, { useEffect, useState, memo } from 'react'
+import React, { memo, useState } from 'react'
 
 import { Button, IconButton } from 'src/components/buttons'
+import { TextInput } from 'src/components/inputs'
+import { H4 } from 'src/components/typography'
 import { ReactComponent as CloseIcon } from 'src/styling/icons/action/close/zodiac.svg'
+import { spacer } from 'src/styling/variables'
 
-import { TextInput } from './inputs'
-import { H4, P } from './typography'
+import ErrorMessage from './ErrorMessage'
 
 const useStyles = makeStyles({
-  label: {
-    fontSize: 16
+  dialogContent: {
+    width: 434,
+    padding: spacer * 2,
+    paddingRight: spacer * 3.5
   },
-  spacing: {
-    padding: 32
+  dialogTitle: {
+    padding: spacer * 2,
+    paddingRight: spacer * 1.5,
+    display: 'flex',
+    'justify-content': 'space-between',
+    '& > h4': {
+      margin: 0
+    },
+    '& > button': {
+      padding: 0,
+      marginTop: -(spacer / 2)
+    }
   },
-  wrapper: {
-    display: 'flex'
-  },
-  title: {
-    margin: [[20, 0, 24, 16]]
-  },
-  closeButton: {
-    padding: 0,
-    margin: [[12, 12, 'auto', 'auto']]
-    // position: 'absolute',
-    // right: spacer,
-    // top: spacer
+  dialogActions: {
+    padding: spacer * 4,
+    paddingTop: spacer * 2
   }
 })
 
 export const DialogTitle = ({ children, onClose }) => {
   const classes = useStyles()
   return (
-    <div className={classes.wrapper}>
+    <div className={classes.dialogTitle}>
       {children}
       {onClose && (
-        <IconButton
-          size={16}
-          aria-label="close"
-          className={classes.closeButton}
-          onClick={onClose}>
+        <IconButton size={16} aria-label="close" onClick={onClose}>
           <CloseIcon />
         </IconButton>
       )}
@@ -56,48 +56,51 @@ export const DialogTitle = ({ children, onClose }) => {
 export const ConfirmDialog = memo(
   ({
     title = 'Confirm action',
-    subtitle = 'This action requires confirmation',
+    errorMessage = 'This action requires confirmation',
     open,
     toBeConfirmed,
     onConfirmed,
     onDissmised,
-    className,
     ...props
   }) => {
     const classes = useStyles()
     const [value, setValue] = useState('')
-    useEffect(() => setValue(''), [open])
-    const handleChange = event => {
-      setValue(event.target.value)
-    }
+    const handleChange = event => setValue(event.target.value)
 
     return (
       <Dialog open={open} aria-labelledby="form-dialog-title" {...props}>
         <DialogTitle id="customized-dialog-title" onClose={onDissmised}>
-          <H4 className={classes.title}>{title}</H4>
-          {subtitle && (
-            <DialogContentText>
-              <P>{subtitle}</P>
-            </DialogContentText>
-          )}
+          <H4>{title}</H4>
         </DialogTitle>
-        <DialogContent className={className}>
+        {errorMessage && (
+          <DialogTitle>
+            <ErrorMessage>
+              {errorMessage.split(':').map(error => (
+                <>
+                  {error}
+                  <br />
+                </>
+              ))}
+            </ErrorMessage>
+          </DialogTitle>
+        )}
+        <DialogContent className={classes.dialogContent}>
           <TextInput
-            label={`Write '${toBeConfirmed}' to confirm`}
+            label={`Write '${toBeConfirmed}' to confirm this action`}
             name="confirm-input"
             autoFocus
             id="confirm-input"
             type="text"
-            size="lg"
+            size="sm"
             fullWidth
             value={value}
             touched={{}}
             error={toBeConfirmed !== value}
-            InputLabelProps={{ shrink: true, className: classes.label }}
+            InputLabelProps={{ shrink: true }}
             onChange={handleChange}
           />
         </DialogContent>
-        <DialogActions classes={{ spacing: classes.spacing }}>
+        <DialogActions className={classes.dialogActions}>
           <Button
             color="green"
             disabled={toBeConfirmed !== value}

--- a/new-lamassu-admin/src/components/Status.js
+++ b/new-lamassu-admin/src/components/Status.js
@@ -11,7 +11,8 @@ import {
   spring3,
   smallestFontSize,
   inputFontFamily,
-  spacer
+  spacer,
+  linen
 } from '../styling/variables'
 
 const colors = {
@@ -22,7 +23,7 @@ const colors = {
 
 const backgroundColors = {
   error: mistyRose,
-  warning: mistyRose,
+  warning: linen,
   success: spring3
 }
 
@@ -33,28 +34,22 @@ const useStyles = makeStyles({
     marginRight: spacer / 4,
     marginBottom: spacer / 2,
     marginLeft: spacer / 4,
-    height: 18,
+    height: spacer * 3,
     backgroundColor: ({ type }) => backgroundColors[type]
   },
   label: {
     fontSize: smallestFontSize,
     fontWeight: inputFontWeight,
     fontFamily: inputFontFamily,
-    padding: [[spacer / 2, spacer]],
+    paddingRight: spacer / 2,
+    paddingLeft: spacer / 2,
     color: ({ type }) => colors[type]
   }
 })
 
-const Status = ({ status, className }) => {
+const Status = ({ status }) => {
   const classes = useStyles({ type: status.type })
-  return (
-    <Chip
-      type={status.type}
-      label={status.label}
-      className={className ?? null}
-      classes={classes}
-    />
-  )
+  return <Chip type={status.type} label={status.label} classes={classes} />
 }
 
 const MainStatus = ({ statuses }) => {
@@ -65,7 +60,7 @@ const MainStatus = ({ statuses }) => {
   const plus = { label: `+${statuses.length - 1}`, type: mainStatus.type }
 
   return (
-    <div style={{ marginLeft: -3 }}>
+    <div>
       <Status status={mainStatus} />
       {statuses.length > 1 && <Status status={plus} />}
     </div>

--- a/new-lamassu-admin/src/pages/Maintenance/MachineDetailsCard.js
+++ b/new-lamassu-admin/src/pages/Maintenance/MachineDetailsCard.js
@@ -1,20 +1,27 @@
 import { useMutation } from '@apollo/react-hooks'
-import { Dialog, DialogContent } from '@material-ui/core'
+import { Grid, Divider } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import gql from 'graphql-tag'
 import moment from 'moment'
 import React, { useState } from 'react'
 
-import { DialogTitle, ConfirmDialog } from 'src/components/ConfirmDialog'
+import { ConfirmDialog } from 'src/components/ConfirmDialog'
 import { Status } from 'src/components/Status'
 import ActionButton from 'src/components/buttons/ActionButton'
-import { Label1, H4 } from 'src/components/typography'
+import {
+  detailsRowStyles,
+  labelStyles
+} from 'src/pages/Transactions/Transactions.styles'
+import { ReactComponent as DownloadReversedIcon } from 'src/styling/icons/button/download/white.svg'
+import { ReactComponent as DownloadIcon } from 'src/styling/icons/button/download/zodiac.svg'
+import { ReactComponent as LinkIcon } from 'src/styling/icons/button/link/zodiac.svg'
 import { ReactComponent as RebootReversedIcon } from 'src/styling/icons/button/reboot/white.svg'
 import { ReactComponent as RebootIcon } from 'src/styling/icons/button/reboot/zodiac.svg'
+import { ReactComponent as ShutdownReversedIcon } from 'src/styling/icons/button/shut down/white.svg'
+import { ReactComponent as ShutdownIcon } from 'src/styling/icons/button/shut down/zodiac.svg'
 import { ReactComponent as UnpairReversedIcon } from 'src/styling/icons/button/unpair/white.svg'
 import { ReactComponent as UnpairIcon } from 'src/styling/icons/button/unpair/zodiac.svg'
-
-import styles from './MachineDetailsCard.styles'
+import { spacer, comet, primaryColor } from 'src/styling/variables'
 
 const MACHINE_ACTION = gql`
   mutation MachineAction($deviceId: ID!, $action: MachineAction!) {
@@ -24,150 +31,240 @@ const MACHINE_ACTION = gql`
   }
 `
 
-const useStyles = makeStyles(styles)
+const supportArtices = [
+  {
+    // Default article for non-maped statuses
+    code: undefined,
+    label: 'Troubleshooting',
+    article:
+      'https://support.lamassu.is/hc/en-us/categories/115000075249-Troubleshooting'
+  }
+]
 
-const Label = ({ children }) => {
-  const classes = useStyles()
-  return <Label1 className={classes.label}>{children}</Label1>
+const article = ({ code: status }) =>
+  supportArtices.find(({ code: article }) => article === status)
+
+const colDivider = {
+  width: 1,
+  margin: [[spacer * 2, spacer * 4]],
+  backgroundColor: comet,
+  border: 'none'
 }
 
-const MachineDetailsRow = ({ it: machine }) => {
-  const [errorDialog, setErrorDialog] = useState(false)
-  const [dialogOpen, setOpen] = useState(false)
-  const [actionMessage, setActionMessage] = useState(null)
-  const classes = useStyles()
+const inlineChip = {
+  marginInlineEnd: '0.25em'
+}
 
-  const unpairDialog = () => setOpen(true)
+const useLStyles = makeStyles(labelStyles)
+
+const Label = ({ children }) => {
+  const classes = useLStyles()
+
+  return <div className={classes.label}>{children}</div>
+}
+
+const stack = {
+  display: 'flex',
+  flexDirection: 'row'
+}
+
+const useMDStyles = makeStyles({
+  ...detailsRowStyles,
+  colDivider,
+  inlineChip,
+  stack,
+  details: {
+    height: '100%',
+    padding: [[spacer * 3, 0]]
+  },
+  list: {
+    padding: 0,
+    margin: 0,
+    listStyle: 'none',
+    '& > li': {
+      height: spacer * 3,
+      marginBottom: spacer * 1.5,
+      '& > a, & > a:visited': {
+        color: primaryColor,
+        textDecoration: 'none'
+      }
+    }
+  },
+  divider: {
+    margin: '0 1rem'
+  },
+  mr: {
+    marginRight: spacer
+  }
+})
+
+const Container = ({ children, ...props }) => (
+  <Grid container spacing={4} {...props}>
+    {children}
+  </Grid>
+)
+
+const Item = ({ children, ...props }) => (
+  <Grid item xs {...props}>
+    {children}
+  </Grid>
+)
+
+const MachineDetailsRow = ({ it: machine, onActionSuccess }) => {
+  const [action, setAction] = useState('')
+  const [dialogOpen, setOpen] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(null)
+  const classes = useMDStyles()
+
+  const confirmDialog = action => setAction(action) || setOpen(true)
 
   const [machineAction, { loading }] = useMutation(MACHINE_ACTION, {
-    onError: ({ graphQLErrors, message }) => {
-      const errorMessage = graphQLErrors[0] ? graphQLErrors[0].message : message
-      setActionMessage(errorMessage)
-      setErrorDialog(true)
+    onError: ({ message }) => {
+      const errorMessage = message ?? 'An error ocurred'
+      setErrorMessage(errorMessage)
+    },
+    onCompleted: () => {
+      // TODO: custom onActionSuccess needs to be passed down from the machinestatus table
+      onActionSuccess ? onActionSuccess() : window.location.reload()
+      setOpen(false)
     }
   })
 
   return (
     <>
-      <Dialog open={errorDialog} aria-labelledby="form-dialog-title">
-        <DialogTitle
-          id="customized-dialog-title"
-          onClose={() => setErrorDialog(false)}>
-          <H4>Error</H4>
-        </DialogTitle>
-        <DialogContent>{actionMessage}</DialogContent>
-      </Dialog>
-      <div className={classes.wrapper}>
-        <div className={classes.column1}>
-          <div className={classes.lastRow}>
-            <div className={classes.status}>
+      <Container className={classes.details}>
+        <Item xs={5}>
+          <Container>
+            <Item>
               <Label>Statuses</Label>
-              <div>
+              <ul className={classes.list}>
                 {machine.statuses.map((status, index) => (
-                  <Status
-                    className={classes.chips}
-                    status={status}
-                    key={index}
-                  />
+                  <li key={index}>
+                    <Status status={status} />
+                  </li>
                 ))}
-              </div>
-            </div>
-            <div>
+              </ul>
+            </Item>
+            <Item>
               <Label>Lamassu Support article</Label>
-              <div>
-                {machine.statuses.map((...[, index]) => (
-                  // TODO support articles
-                  <span key={index}></span>
-                ))}
-              </div>
-            </div>
-            <div className={classes.separator} />
-          </div>
-        </div>
-        <div className={classes.column2}>
-          <div className={classes.row}>
-            <div className={classes.machineModel}>
+              <ul className={classes.list}>
+                {machine.statuses
+                  .map(article)
+                  .map(({ label, article }, index) => (
+                    <li key={index}>
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={article}>
+                        '{label}' <LinkIcon />
+                      </a>
+                    </li>
+                  ))}
+              </ul>
+            </Item>
+          </Container>
+        </Item>
+        <Divider
+          orientation="vertical"
+          flexItem
+          className={classes.colDivider}
+        />
+        <ConfirmDialog
+          open={dialogOpen}
+          title={`${action} this machine?`}
+          errorMessage={errorMessage}
+          toBeConfirmed={machine.name}
+          onConfirmed={() => {
+            setErrorMessage(null)
+            machineAction({
+              variables: {
+                deviceId: machine.deviceId,
+                action: `${action}`.toLowerCase()
+              }
+            })
+          }}
+          onDissmised={() => {
+            setOpen(false)
+            setErrorMessage(null)
+          }}
+        />
+        <Item xs>
+          <Container>
+            <Item xs={4}>
               <Label>Machine Model</Label>
-              <div>{machine.model ?? 'unknown'}</div>
-            </div>
-            <div>
+              <span>{machine.model}</span>
+            </Item>
+            <Item>
+              <Label>Address</Label>
+              <span>{machine.machineLocation}</span>
+            </Item>
+          </Container>
+          <Container>
+            <Item xs={4}>
               <Label>Paired at</Label>
-              <div>
-                {machine.pairedAt
-                  ? moment(machine.pairedAt).format('YYYY-MM-DD HH:mm:ss')
-                  : 'N/A'}
-              </div>
-            </div>
-          </div>
-          <div className={classes.lastRow}>
-            <div>
-              <Label>Actions</Label>
-              <div className={classes.actionRow}>
+              <span>
+                {moment(machine.pairedAt).format('YYYY-MM-DD HH:mm:ss')}
+              </span>
+            </Item>
+            <Item>
+              <Label>Software update</Label>
+
+              <div className={classes.stack}>
+                {machine.version && (
+                  <span className={classes.mr}>{machine.version}</span>
+                )}
                 <ActionButton
-                  className={classes.action}
                   color="primary"
+                  Icon={DownloadIcon}
+                  InverseIcon={DownloadReversedIcon}
+                  className={classes.mr}
+                  disabled={loading}
+                  onClick={() => confirmDialog('Update')}>
+                  Update
+                </ActionButton>
+              </div>
+            </Item>
+          </Container>
+          <Container>
+            <Item xs={4}>
+              <Label>Printer</Label>
+              <div>{machine.printer || 'unknown'}</div>
+            </Item>
+            <Item>
+              <Label>Actions</Label>
+              <div className={classes.stack}>
+                <ActionButton
+                  color="primary"
+                  className={classes.mr}
                   Icon={UnpairIcon}
                   InverseIcon={UnpairReversedIcon}
                   disabled={loading}
-                  onClick={unpairDialog}>
+                  onClick={() => confirmDialog('Unpair')}>
                   Unpair
                 </ActionButton>
-                <ConfirmDialog
-                  open={dialogOpen}
-                  className={classes.dialog}
-                  title="Unpair this machine?"
-                  subtitle={false}
-                  toBeConfirmed={machine.name}
-                  onConfirmed={() => {
-                    setOpen(false)
-                    machineAction({
-                      variables: {
-                        deviceId: machine.deviceId,
-                        action: 'unpair'
-                      }
-                    })
-                  }}
-                  onDissmised={() => {
-                    setOpen(false)
-                  }}
-                />
                 <ActionButton
-                  className={classes.action}
                   color="primary"
+                  className={classes.mr}
                   Icon={RebootIcon}
                   InverseIcon={RebootReversedIcon}
                   disabled={loading}
-                  onClick={() => {
-                    machineAction({
-                      variables: {
-                        deviceId: machine.deviceId,
-                        action: 'reboot'
-                      }
-                    })
-                  }}>
+                  onClick={() => confirmDialog('Reboot')}>
                   Reboot
                 </ActionButton>
                 <ActionButton
-                  className={classes.action}
+                  className={classes.inlineChip}
                   disabled={loading}
                   color="primary"
-                  Icon={RebootIcon}
-                  InverseIcon={RebootReversedIcon}
-                  onClick={() => {
-                    machineAction({
-                      variables: {
-                        deviceId: machine.deviceId,
-                        action: 'restartServices'
-                      }
-                    })
-                  }}>
-                  Restart Services
+                  Icon={ShutdownIcon}
+                  InverseIcon={ShutdownReversedIcon}
+                  onClick={() => confirmDialog('Shutdown')}>
+                  Shutdown
                 </ActionButton>
               </div>
-            </div>
-          </div>
-        </div>
-      </div>
+            </Item>
+          </Container>
+        </Item>
+      </Container>
     </>
   )
 }

--- a/new-lamassu-admin/src/pages/Maintenance/MachineStatus.js
+++ b/new-lamassu-admin/src/pages/Maintenance/MachineStatus.js
@@ -5,13 +5,12 @@ import moment from 'moment'
 import * as R from 'ramda'
 import React from 'react'
 
+import { MainStatus } from 'src/components/Status'
+import Title from 'src/components/Title'
 import DataTable from 'src/components/tables/DataTable'
-
-import { MainStatus } from '../../components/Status'
-import Title from '../../components/Title'
-import { ReactComponent as WarningIcon } from '../../styling/icons/status/pumpkin.svg'
-import { ReactComponent as ErrorIcon } from '../../styling/icons/status/tomato.svg'
-import { mainStyles } from '../Transactions/Transactions.styles'
+import { mainStyles } from 'src/pages/Transactions/Transactions.styles'
+import { ReactComponent as WarningIcon } from 'src/styling/icons/status/pumpkin.svg'
+import { ReactComponent as ErrorIcon } from 'src/styling/icons/status/tomato.svg'
 
 import MachineDetailsRow from './MachineDetailsCard'
 
@@ -26,6 +25,8 @@ const GET_MACHINES = gql`
       cashbox
       cassette1
       cassette2
+      version
+      model
       statuses {
         label
         type
@@ -44,31 +45,38 @@ const MachineStatus = () => {
   const elements = [
     {
       header: 'Machine Name',
-      width: 250,
+      width: 232,
       size: 'sm',
       textAlign: 'left',
       view: m => m.name
     },
     {
       header: 'Status',
-      width: 350,
+      width: 349,
       size: 'sm',
       textAlign: 'left',
       view: m => <MainStatus statuses={m.statuses} />
     },
     {
       header: 'Last ping',
-      width: 200,
+      width: 192,
       size: 'sm',
       textAlign: 'left',
-      view: m => (m.lastPing ? moment(m.lastPing).fromNow() : 'unknown')
+      view: m => moment(m.lastPing).fromNow()
+    },
+    {
+      header: 'Ping Time',
+      width: 155,
+      size: 'sm',
+      textAlign: 'left',
+      view: m => m.pingTime || 'unknown'
     },
     {
       header: 'Software Version',
-      width: 200,
+      width: 201,
       size: 'sm',
       textAlign: 'left',
-      view: m => m.softwareVersion || 'unknown'
+      view: m => m.version || 'unknown'
     }
   ]
 

--- a/new-lamassu-admin/src/styling/icons/button/reboot/white.svg
+++ b/new-lamassu-admin/src/styling/icons/button/reboot/white.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="12px" height="12px" viewBox="-0.493 -0.5 12.993 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
     <title>icon/button/reboot/white</title>
     <desc>Created with Sketch.</desc>

--- a/new-lamassu-admin/src/styling/icons/button/reboot/zodiac.svg
+++ b/new-lamassu-admin/src/styling/icons/button/reboot/zodiac.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="12px" height="12px" viewBox="-0.493 -0.5 12.993 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
     <title>icon/button/reboot/zodiac</title>
     <desc>Created with Sketch.</desc>


### PR DESCRIPTION
- [x]     legend colors are different from the spec
- [x]     align popup title with content (unpair action)
- [x]     reboot icon is being cut off, fix it.
- [x]     make all actions open up a pop-up like the unpair one
- [x]     popups should only close in case of success. If it errors show the error like the 3rd party service ones.
- [x]     add support articles for every status
- [ ]     load machine model from l-m
- [ ]     properly display statuses based on machine-pings and machine-state

fix: reboot icon looks cropped
fix: confirm dialog layout
fix: Status chip background colors
fix: detailed machine status layout
fix: machine detailed status layout
fix: machine status article links, status chip size
fix: confirmDialog for all machine actions
fix: confirm dialog on every action. reload when success