### PR TITLE
fix: Locale overrides should only allow one row per machine

### DIFF
--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -69,6 +69,18 @@ const Locales = ({ name: SCREEN_KEY }) => {
     return saveConfig({ variables: { config } })
   }
 
+  const removeOverridenMachines = data => {
+    if (data) {
+      const overridenMachines = locale.overrides?.map(o => o.machine)
+      const machinesIndex = data.findIndex(o => o.name === 'machine')
+      data[machinesIndex].inputProps.options = data[
+        machinesIndex
+      ].inputProps.options?.filter(m => !overridenMachines.includes(m.deviceId))
+    }
+
+    return data
+  }
+
   return (
     <>
       <TitleSection title="Locales" />
@@ -97,7 +109,7 @@ const Locales = ({ name: SCREEN_KEY }) => {
           save={saveOverrides}
           validationSchema={OverridesSchema}
           data={locale.overrides ?? []}
-          elements={overrides(data)}
+          elements={removeOverridenMachines(overrides(data))}
         />
       </Section>
     </>

--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -58,6 +58,7 @@ const Locales = ({ name: SCREEN_KEY }) => {
   const config = data?.config && fromNamespace(SCREEN_KEY)(data.config)
 
   const locale = config && !R.isEmpty(config) ? config : localeDefaults
+  const localeOverrides = locale.overrides ?? []
 
   const save = it => {
     const config = toNamespace(SCREEN_KEY)(it.locale[0])
@@ -67,18 +68,6 @@ const Locales = ({ name: SCREEN_KEY }) => {
   const saveOverrides = it => {
     const config = toNamespace(SCREEN_KEY)(it)
     return saveConfig({ variables: { config } })
-  }
-
-  const removeOverridenMachines = data => {
-    if (data) {
-      const overridenMachines = locale.overrides?.map(o => o.machine)
-      const machinesIndex = data.findIndex(o => o.name === 'machine')
-      data[machinesIndex].inputProps.options = data[
-        machinesIndex
-      ].inputProps.options?.filter(m => !overridenMachines.includes(m.deviceId))
-    }
-
-    return data
   }
 
   return (
@@ -108,8 +97,8 @@ const Locales = ({ name: SCREEN_KEY }) => {
           initialValues={overridesDefaults}
           save={saveOverrides}
           validationSchema={OverridesSchema}
-          data={locale.overrides ?? []}
-          elements={removeOverridenMachines(overrides(data))}
+          data={localeOverrides}
+          elements={overrides(data, localeOverrides)}
         />
       </Section>
     </>

--- a/new-lamassu-admin/src/pages/Locales/helper.js
+++ b/new-lamassu-admin/src/pages/Locales/helper.js
@@ -23,13 +23,6 @@ const allFields = (getData, auxElements = []) => {
     )(data)
   }
 
-  const findSuggestion = (it, machines) => {
-    const machine = R.compose(R.find(R.propEq('deviceId', it?.machine)))(
-      machines
-    )
-    return machine ? [machine] : []
-  }
-
   const displayCodeArray = data => it => {
     if (!it) return it
 
@@ -37,9 +30,9 @@ const allFields = (getData, auxElements = []) => {
   }
 
   const overridenMachines = R.map(override => override.machine, auxElements)
-  const suggestionFilter = R.filter(
-    it => !R.contains(it.deviceId, overridenMachines)
-  )
+
+  const suggestionFilter = it =>
+    R.differenceWith((x, y) => x.deviceId === y, it, overridenMachines)
 
   const machineData = getData(['machines'])
   const countryData = getData(['countries'])
@@ -55,9 +48,8 @@ const allFields = (getData, auxElements = []) => {
       input: Autocomplete,
       inputProps: {
         options: it =>
-          R.concat(
-            suggestionFilter(machineData),
-            findSuggestion(it, machineData)
+          R.concat(it?.machine ? [it.machine] : [])(
+            suggestionFilter(machineData)
           ),
         valueProp: 'deviceId',
         getLabel: R.path(['name']),

--- a/new-lamassu-admin/src/pages/Locales/helper.js
+++ b/new-lamassu-admin/src/pages/Locales/helper.js
@@ -41,8 +41,6 @@ const allFields = (getData, auxElements = []) => {
     it => !R.contains(it.deviceId, overridenMachines)
   )
 
-  console.log(getData(['machines']))
-
   const machineData = getData(['machines'])
   const countryData = getData(['countries'])
   const currencyData = getData(['currencies'])

--- a/new-lamassu-admin/src/pages/Locales/helper.js
+++ b/new-lamassu-admin/src/pages/Locales/helper.js
@@ -6,11 +6,14 @@ import Autocomplete from 'src/components/inputs/formik/Autocomplete.js'
 
 const LANGUAGE_SELECTION_LIMIT = 4
 
-const getFields = (getData, names) => {
-  return R.filter(it => R.includes(it.name, names), allFields(getData))
+const getFields = (getData, names, auxElements = []) => {
+  return R.filter(
+    it => R.includes(it.name, names),
+    allFields(getData, auxElements)
+  )
 }
 
-const allFields = getData => {
+const allFields = (getData, auxElements = []) => {
   const getView = (data, code, compare) => it => {
     if (!data) return ''
 
@@ -20,11 +23,25 @@ const allFields = getData => {
     )(data)
   }
 
+  const findSuggestion = (it, machines) => {
+    const machine = R.compose(R.find(R.propEq('deviceId', it?.machine)))(
+      machines
+    )
+    return machine ? [machine] : []
+  }
+
   const displayCodeArray = data => it => {
     if (!it) return it
 
     return R.compose(R.join(', '), R.map(getView(data, 'code')))(it)
   }
+
+  const overridenMachines = R.map(override => override.machine, auxElements)
+  const suggestionFilter = R.filter(
+    it => !R.contains(it.deviceId, overridenMachines)
+  )
+
+  console.log(getData(['machines']))
 
   const machineData = getData(['machines'])
   const countryData = getData(['countries'])
@@ -39,7 +56,11 @@ const allFields = getData => {
       view: getView(machineData, 'name', 'deviceId'),
       input: Autocomplete,
       inputProps: {
-        options: machineData,
+        options: it =>
+          R.concat(
+            suggestionFilter(machineData),
+            findSuggestion(it, machineData)
+          ),
         valueProp: 'deviceId',
         getLabel: R.path(['name']),
         limit: null
@@ -113,15 +134,14 @@ const mainFields = auxData => {
   ])
 }
 
-const overrides = auxData => {
+const overrides = (auxData, auxElements) => {
   const getData = R.path(R.__, auxData)
 
-  return getFields(getData, [
-    'machine',
-    'country',
-    'languages',
-    'cryptoCurrencies'
-  ])
+  return getFields(
+    getData,
+    ['machine', 'country', 'languages', 'cryptoCurrencies'],
+    auxElements
+  )
 }
 
 const LocaleSchema = Yup.object().shape({


### PR DESCRIPTION
fix: filter already overriden machines on locales