### PR TITLE
chore: v7.4.10, update zcashd

### DIFF
--- a/lib/blockchain/common.js
+++ b/lib/blockchain/common.js
@@ -29,8 +29,8 @@ const BINARIES = {
     dir: 'geth-linux-amd64-1.9.19-3e064192'
   },
   ZEC: {
-    url: 'https://z.cash/downloads/zcash-3.1.0-linux64-debian-jessie.tar.gz',
-    dir: 'zcash-3.1.0/bin'
+    url: 'https://download.z.cash/downloads/zcash-4.0.0-linux64-debian-stretch.tar.gz',
+    dir: 'zcash-4.0.0/bin'
   },
   DASH: {
     url: 'https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-x86_64-linux-gnu.tar.gz',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-server",
-  "version": "7.4.8",
+  "version": "7.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lamassu-server",
   "description": "bitcoin atm client server protocol module",
   "keywords": [],
-  "version": "7.4.9",
+  "version": "7.4.10",
   "license": "Unlicense",
   "author": "Lamassu (https://lamassu.is)",
   "dependencies": {


### PR DESCRIPTION
Updates zcashd to support November's Canopy update.

See: https://github.com/lamassu/lamassu-patches/pull/11 & https://github.com/lamassu/lamassu-install/pull/45