### PR TITLE
fix: validation and input widths

### DIFF
--- a/new-lamassu-admin/src/pages/Cashout/helper.js
+++ b/new-lamassu-admin/src/pages/Cashout/helper.js
@@ -2,10 +2,20 @@ import * as Yup from 'yup'
 
 import { NumberInput } from 'src/components/inputs/formik'
 
+const currencyMax = 999999999
 const DenominationsSchema = Yup.object().shape({
-  top: Yup.number().required('Required'),
-  bottom: Yup.number().required('Required'),
-  zeroConfLimit: Yup.number().required('Required')
+  top: Yup.number()
+    .required('Required')
+    .min(0)
+    .max(currencyMax),
+  bottom: Yup.number()
+    .required('Required')
+    .min(0)
+    .max(currencyMax),
+  zeroConfLimit: Yup.number()
+    .required('Required')
+    .min(0)
+    .max(currencyMax)
 })
 
 const getElements = (machines, { fiatCurrency } = {}) => {

--- a/new-lamassu-admin/src/pages/Commissions/helper.js
+++ b/new-lamassu-admin/src/pages/Commissions/helper.js
@@ -200,20 +200,24 @@ const overrides = (auxData, currency, auxElements) => {
   return getOverridesFields(getData, currency, auxElements)
 }
 
+const percentMax = 100
+const currencyMax = 9999999
 const schema = Yup.object().shape({
   cashIn: Yup.number()
     .min(0)
-    .max(100)
+    .max(percentMax)
     .required('Required'),
   cashOut: Yup.number()
     .min(0)
-    .max(100)
+    .max(percentMax)
     .required('Required'),
   fixedFee: Yup.number()
     .min(0)
+    .max(currencyMax)
     .required('Required'),
   minimumTx: Yup.number()
     .min(0)
+    .max(currencyMax)
     .required('Required')
 })
 
@@ -222,17 +226,19 @@ const OverridesSchema = Yup.object().shape({
   cryptoCurrencies: Yup.array().required('Required'),
   cashIn: Yup.number()
     .min(0)
-    .max(100)
+    .max(percentMax)
     .required('Required'),
   cashOut: Yup.number()
     .min(0)
-    .max(100)
+    .max(percentMax)
     .required('Required'),
   fixedFee: Yup.number()
     .min(0)
+    .max(currencyMax)
     .required('Required'),
   minimumTx: Yup.number()
     .min(0)
+    .max(currencyMax)
     .required('Required')
 })
 

--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -160,6 +160,10 @@ const Locales = ({ name: SCREEN_KEY }) => {
           validationSchema={OverridesSchema}
           data={localeOverrides ?? []}
           elements={overrides(data, localeOverrides)}
+          disableAdd={R.compose(R.isEmpty, R.difference)(
+            data?.machines.map(m => m.deviceId) ?? [],
+            localeOverrides?.map(o => o.machine) ?? []
+          )}
           setEditing={onEditingOverrides}
           forceDisable={isEditingDefault}
         />

--- a/new-lamassu-admin/src/pages/Notifications/components/SingleFieldEditableNumber.js
+++ b/new-lamassu-admin/src/pages/Notifications/components/SingleFieldEditableNumber.js
@@ -13,6 +13,8 @@ const SingleFieldEditableNumber = ({
   title,
   label,
   width = 80,
+  min = 0,
+  max = 9999999,
   name,
   section,
   className
@@ -42,7 +44,8 @@ const SingleFieldEditableNumber = ({
   const schema = Yup.object().shape({
     [name]: Yup.number()
       .integer()
-      .min(0)
+      .min(min)
+      .max(max)
       .required()
   })
 

--- a/new-lamassu-admin/src/pages/Notifications/sections/CryptoBalanceOverrides.js
+++ b/new-lamassu-admin/src/pages/Notifications/sections/CryptoBalanceOverrides.js
@@ -51,15 +51,18 @@ const CryptoBalanceOverrides = ({ section }) => {
     [HIGH_BALANCE_KEY]: ''
   }
 
+  const currencyMax = 9999999
   const validationSchema = Yup.object().shape({
     [CRYPTOCURRENCY_KEY]: Yup.string().required(),
     [LOW_BALANCE_KEY]: Yup.number()
       .integer()
       .min(0)
+      .max(currencyMax)
       .required(),
     [HIGH_BALANCE_KEY]: Yup.number()
       .integer()
       .min(0)
+      .max(currencyMax)
       .required()
   })
 

--- a/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceOverrides.js
+++ b/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceOverrides.js
@@ -38,15 +38,18 @@ const FiatBalanceOverrides = ({ section }) => {
     [CASSETTE_2_KEY]: ''
   }
 
+  const notesMax = 9999999
   const validationSchema = Yup.object().shape({
     [MACHINE_KEY]: Yup.string().required(),
     [CASSETTE_1_KEY]: Yup.number()
       .integer()
       .min(0)
+      .max(notesMax)
       .required(),
     [CASSETTE_2_KEY]: Yup.number()
       .integer()
       .min(0)
+      .max(notesMax)
       .required()
   })
 


### PR DESCRIPTION
fix: cash-out fields now accepts only positive values

fix: add max values for fields on Cashout, Commissions, Notifications

fix: disable adding on the Locales overrides when all of the machines
are already overriden