### PR TITLE
fix: No reason for 'Enable' switch on 'Wallet Settings' panel

### DIFF
--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -175,7 +175,8 @@ const ERow = ({ editing, disabled, lastOfGroup }) => {
     enableDelete,
     enableToggle,
     rowSize,
-    stripeWhen
+    stripeWhen,
+    focusOnEditWhen
   } = useContext(TableCtx)
 
   const classes = useStyles()
@@ -214,7 +215,12 @@ const ERow = ({ editing, disabled, lastOfGroup }) => {
             key={idx}
             config={it}
             editing={editing}
-            focus={idx === elementToFocusIndex && editing}
+            focus={
+              idx === elementToFocusIndex &&
+              editing &&
+              focusOnEditWhen &&
+              focusOnEditWhen(values)
+            }
             extraPaddingRight={extraPaddingRightIndex === idx}
             extraPaddingLeft={extraPaddingLeftIndex === idx}
           />

--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -176,7 +176,7 @@ const ERow = ({ editing, disabled, lastOfGroup }) => {
     enableToggle,
     rowSize,
     stripeWhen,
-    focusOnEditWhen
+    focusOnEditWhen = () => true
   } = useContext(TableCtx)
 
   const classes = useStyles()

--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -175,8 +175,7 @@ const ERow = ({ editing, disabled, lastOfGroup }) => {
     enableDelete,
     enableToggle,
     rowSize,
-    stripeWhen,
-    focusOnEditWhen = () => true
+    stripeWhen
   } = useContext(TableCtx)
 
   const classes = useStyles()
@@ -215,12 +214,7 @@ const ERow = ({ editing, disabled, lastOfGroup }) => {
             key={idx}
             config={it}
             editing={editing}
-            focus={
-              idx === elementToFocusIndex &&
-              editing &&
-              focusOnEditWhen &&
-              focusOnEditWhen(values)
-            }
+            focus={idx === elementToFocusIndex && editing}
             extraPaddingRight={extraPaddingRightIndex === idx}
             extraPaddingLeft={extraPaddingLeftIndex === idx}
           />

--- a/new-lamassu-admin/src/components/editableTable/Table.js
+++ b/new-lamassu-admin/src/components/editableTable/Table.js
@@ -46,7 +46,8 @@ const ETable = ({
   disableAdd,
   initialValues,
   setEditing,
-  focusOnEditWhen,
+  shouldOverrideEdit,
+  editOverride,
   stripeWhen,
   disableRowEdit,
   groupBy,
@@ -93,6 +94,7 @@ const ETable = ({
   }
 
   const onEdit = it => {
+    if (shouldOverrideEdit && shouldOverrideEdit(it)) return editOverride(it)
     setEditingId(it)
     setEditing && setEditing(it, true)
   }
@@ -136,7 +138,6 @@ const ETable = ({
     toggleWidth,
     actionColSize,
     stripeWhen,
-    focusOnEditWhen,
     DEFAULT_COL_SIZE
   }
 

--- a/new-lamassu-admin/src/components/editableTable/Table.js
+++ b/new-lamassu-admin/src/components/editableTable/Table.js
@@ -46,6 +46,7 @@ const ETable = ({
   disableAdd,
   initialValues,
   setEditing,
+  focusOnEditWhen,
   stripeWhen,
   disableRowEdit,
   groupBy,
@@ -135,6 +136,7 @@ const ETable = ({
     toggleWidth,
     actionColSize,
     stripeWhen,
+    focusOnEditWhen,
     DEFAULT_COL_SIZE
   }
 

--- a/new-lamassu-admin/src/components/inputs/formik/Autocomplete.js
+++ b/new-lamassu-admin/src/components/inputs/formik/Autocomplete.js
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 
 import { Autocomplete } from '../base'
 
-const AutocompleteFormik = ({ options, ...props }) => {
+const AutocompleteFormik = ({ options, onChange, ...props }) => {
   const [open, setOpen] = useState(false)
 
   const { name, onBlur, value } = props.field
@@ -23,7 +23,10 @@ const AutocompleteFormik = ({ options, ...props }) => {
   return (
     <Autocomplete
       name={name}
-      onChange={(event, item) => setFieldValue(name, item)}
+      onChange={(event, item) => {
+        onChange && onChange(value, item)
+        setFieldValue(name, item)
+      }}
       onBlur={innerOnBlur}
       value={value}
       error={error}

--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -196,10 +196,7 @@ const Locales = ({ name: SCREEN_KEY }) => {
       {wizard && (
         <Wizard
           coin={R.find(R.propEq('code', wizard))(cryptoCurrencies)}
-          onClose={v => {
-            console.log(v)
-            setWizard(false)
-          }}
+          onClose={() => setWizard(false)}
           save={rawConfig => save(toNamespace(namespaces.WALLETS)(rawConfig))}
           error={error}
           cryptoCurrencies={cryptoCurrencies}

--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -10,9 +10,8 @@ import { Table as EditableTable } from 'src/components/editableTable'
 import Section from 'src/components/layout/Section'
 import TitleSection from 'src/components/layout/TitleSection'
 import { P } from 'src/components/typography'
+import Wizard from 'src/pages/Wallet/Wizard'
 import { fromNamespace, toNamespace, namespaces } from 'src/utils/config'
-
-import Wizard from '../Wallet/Wizard'
 
 import { styles } from './Locales.styles'
 import {
@@ -132,7 +131,6 @@ const Locales = ({ name: SCREEN_KEY }) => {
   }
 
   const save = config => {
-    console.log(config)
     setDataToSave(null)
     setError(false)
     saveConfig({ variables: { config } })
@@ -144,8 +142,6 @@ const Locales = ({ name: SCREEN_KEY }) => {
   }
 
   const enableCoin = it => {
-    if (!it) return
-
     const namespaced = fromNamespace(it)(wallets)
     if (!namespaced?.active) return setWizard(it)
   }
@@ -200,7 +196,10 @@ const Locales = ({ name: SCREEN_KEY }) => {
       {wizard && (
         <Wizard
           coin={R.find(R.propEq('code', wizard))(cryptoCurrencies)}
-          onClose={() => setWizard(false)}
+          onClose={v => {
+            console.log(v)
+            setWizard(false)
+          }}
           save={rawConfig => save(toNamespace(namespaces.WALLETS)(rawConfig))}
           error={error}
           cryptoCurrencies={cryptoCurrencies}

--- a/new-lamassu-admin/src/pages/Locales/Locales.js
+++ b/new-lamassu-admin/src/pages/Locales/Locales.js
@@ -11,6 +11,7 @@ import Section from 'src/components/layout/Section'
 import TitleSection from 'src/components/layout/TitleSection'
 import { P } from 'src/components/typography'
 import Wizard from 'src/pages/Wallet/Wizard'
+import { WalletSchema } from 'src/pages/Wallet/helper'
 import { fromNamespace, toNamespace, namespaces } from 'src/utils/config'
 
 import { styles } from './Locales.styles'
@@ -142,8 +143,10 @@ const Locales = ({ name: SCREEN_KEY }) => {
   }
 
   const enableCoin = it => {
+    if (!it) return
+
     const namespaced = fromNamespace(it)(wallets)
-    if (!namespaced?.active) return setWizard(it)
+    if (!WalletSchema.isValidSync(namespaced)) return setWizard(it)
   }
 
   const onEditingDefault = (it, editing) => setEditingDefault(editing)

--- a/new-lamassu-admin/src/pages/Locales/helper.js
+++ b/new-lamassu-admin/src/pages/Locales/helper.js
@@ -5,14 +5,14 @@ import Autocomplete from 'src/components/inputs/formik/Autocomplete.js'
 
 const LANGUAGE_SELECTION_LIMIT = 4
 
-const getFields = (getData, names, auxElements = []) => {
+const getFields = (getData, names, enableCoin, auxElements = []) => {
   return R.filter(
     it => R.includes(it.name, names),
-    allFields(getData, auxElements)
+    allFields(getData, enableCoin, auxElements)
   )
 }
 
-const allFields = (getData, auxElements = []) => {
+const allFields = (getData, enableCoin, auxElements = []) => {
   const getView = (data, code, compare) => it => {
     if (!data) return ''
 
@@ -103,29 +103,30 @@ const allFields = (getData, auxElements = []) => {
         valueProp: 'code',
         getLabel: R.path(['code']),
         multiple: true,
-        optionsLimit: null
+        optionsLimit: null,
+        onChange: (prev, curr) => enableCoin(R.difference(curr, prev)[0])
       }
     }
   ]
 }
 
-const mainFields = auxData => {
+const mainFields = (auxData, enableCoin) => {
   const getData = R.path(R.__, auxData)
 
-  return getFields(getData, [
-    'country',
-    'fiatCurrency',
-    'languages',
-    'cryptoCurrencies'
-  ])
+  return getFields(
+    getData,
+    ['country', 'fiatCurrency', 'languages', 'cryptoCurrencies'],
+    enableCoin
+  )
 }
 
-const overrides = (auxData, auxElements) => {
+const overrides = (auxData, auxElements, enableCoin) => {
   const getData = R.path(R.__, auxData)
 
   return getFields(
     getData,
     ['machine', 'country', 'languages', 'cryptoCurrencies'],
+    enableCoin,
     auxElements
   )
 }

--- a/new-lamassu-admin/src/pages/Wallet/Wallet.js
+++ b/new-lamassu-admin/src/pages/Wallet/Wallet.js
@@ -56,9 +56,9 @@ const Wallet = ({ name: SCREEN_KEY }) => {
   const cryptoCurrencies = data?.cryptoCurrencies ?? []
   const accounts = data?.accounts ?? []
 
-  const onEdit = id => {
-    const namespaced = fromNamespace(id)(config)
-    if (!WalletSchema.isValidSync(namespaced)) return setWizard(id)
+  const shouldOverrideEdit = it => {
+    const namespaced = fromNamespace(it)(config)
+    return !WalletSchema.isValidSync(namespaced)
   }
 
   return (
@@ -70,8 +70,8 @@ const Wallet = ({ name: SCREEN_KEY }) => {
         data={config}
         stripeWhen={it => !WalletSchema.isValidSync(it)}
         enableEdit
-        setEditing={onEdit}
-        focusOnEditWhen={it => WalletSchema.isValidSync(it)}
+        shouldOverrideEdit={shouldOverrideEdit}
+        editOverride={setWizard}
         editWidth={174}
         save={save}
         validationSchema={WalletSchema}

--- a/new-lamassu-admin/src/pages/Wallet/Wallet.js
+++ b/new-lamassu-admin/src/pages/Wallet/Wallet.js
@@ -56,10 +56,9 @@ const Wallet = ({ name: SCREEN_KEY }) => {
   const cryptoCurrencies = data?.cryptoCurrencies ?? []
   const accounts = data?.accounts ?? []
 
-  const onToggle = id => {
+  const onEdit = id => {
     const namespaced = fromNamespace(id)(config)
     if (!WalletSchema.isValidSync(namespaced)) return setWizard(id)
-    save(toNamespace(id, { active: !namespaced?.active }))
   }
 
   return (
@@ -71,13 +70,11 @@ const Wallet = ({ name: SCREEN_KEY }) => {
         data={config}
         stripeWhen={it => !WalletSchema.isValidSync(it)}
         enableEdit
-        editWidth={134}
-        enableToggle
-        toggleWidth={109}
-        onToggle={onToggle}
+        setEditing={onEdit}
+        focusOnEditWhen={it => WalletSchema.isValidSync(it)}
+        editWidth={174}
         save={save}
         validationSchema={WalletSchema}
-        disableRowEdit={R.compose(R.not, R.path(['active']))}
         elements={getElements(cryptoCurrencies, accountsConfig)}
       />
       {wizard && (


### PR DESCRIPTION
fix: remove the "enable" toggle

fix: make edit available at all times and make it toggle the wizard if
the coin config is empty

fix: disable focus on the first edit

feat: open the coin config wizard when adding a not configured coin on
locales