### PR TITLE
fix: v7.5 - Extend length of accept and cancel button text

### DIFF
--- a/new-lamassu-admin/src/pages/OperatorInfo/TermsConditions.js
+++ b/new-lamassu-admin/src/pages/OperatorInfo/TermsConditions.js
@@ -183,10 +183,10 @@ const TermsConditions = () => {
     text: Yup.string().required(),
     acceptButtonText: Yup.string()
       .required()
-      .max(15, 'Too long'),
+      .max(50, 'Too long'),
     cancelButtonText: Yup.string()
       .required()
-      .max(15, 'Too long')
+      .max(50, 'Too long')
   })
 
   return (


### PR DESCRIPTION
fix: extended length of accept and cancel buttons text to 50 chars