### PR TITLE
fix: v7.5 - Don't include 'bitcoincash:' URI in admin text

### DIFF
--- a/new-lamassu-admin/src/pages/Funding.js
+++ b/new-lamassu-admin/src/pages/Funding.js
@@ -22,6 +22,7 @@ import {
 } from 'src/components/typography'
 import CopyToClipboard from 'src/pages/Transactions/CopyToClipboard'
 import { primaryColor } from 'src/styling/variables'
+import { formatCryptoAddress } from 'src/utils/coin'
 
 import styles from './Funding.styles'
 
@@ -50,7 +51,8 @@ const GET_FUNDING = gql`
   }
 `
 
-const formatAddress = (address = '') => address.replace(/(.{4})/g, '$1 ')
+const formatAddress = (cryptoCode = '', address = '') =>
+  formatCryptoAddress(cryptoCode, address).replace(/(.{4})/g, '$1 ')
 const sumReducer = (acc, value) => acc.plus(value)
 const formatNumber = it => new BigNumber(it).toFormat(2)
 
@@ -202,7 +204,10 @@ const Funding = () => {
                 <Mono className={classes.address}>
                   <strong>
                     <CopyToClipboard buttonClassname={classes.copyToClipboard}>
-                      {formatAddress(selected.fundingAddress)}
+                      {formatAddress(
+                        selected.cryptoCode,
+                        selected.fundingAddress
+                      )}
                     </CopyToClipboard>
                   </strong>
                 </Mono>

--- a/new-lamassu-admin/src/pages/Transactions/DetailsCard.js
+++ b/new-lamassu-admin/src/pages/Transactions/DetailsCard.js
@@ -14,7 +14,7 @@ import { ReactComponent as CamIdIcon } from 'src/styling/icons/ID/photo/zodiac.s
 import { ReactComponent as TxInIcon } from 'src/styling/icons/direction/cash-in.svg'
 import { ReactComponent as TxOutIcon } from 'src/styling/icons/direction/cash-out.svg'
 import { URI } from 'src/utils/apollo'
-import { toUnit } from 'src/utils/coin'
+import { toUnit, formatCryptoAddress } from 'src/utils/coin'
 import { onlyFirstToUpper } from 'src/utils/string'
 
 import CopyToClipboard from './CopyToClipboard'
@@ -22,7 +22,8 @@ import styles from './DetailsCard.styles'
 
 const useStyles = makeStyles(styles)
 
-const formatAddress = (address = '') => address.replace(/(.{5})/g, '$1 ')
+const formatAddress = (cryptoCode = '', address = '') =>
+  formatCryptoAddress(cryptoCode, address).replace(/(.{5})/g, '$1 ')
 
 const getCashOutStatus = it => {
   if (it.hasError) return 'Error'
@@ -181,9 +182,11 @@ const DetailsRow = ({ it: tx }) => {
       </div>
       <div className={classes.secondRow}>
         <div className={classes.address}>
-          <Label>BTC address</Label>
+          <Label>Address</Label>
           <div>
-            <CopyToClipboard>{formatAddress(tx.toAddress)}</CopyToClipboard>
+            <CopyToClipboard>
+              {formatAddress(tx.cryptoCode, tx.toAddress)}
+            </CopyToClipboard>
           </div>
         </div>
         <div className={classes.transactionId}>

--- a/new-lamassu-admin/src/pages/Transactions/Transactions.js
+++ b/new-lamassu-admin/src/pages/Transactions/Transactions.js
@@ -11,7 +11,7 @@ import Title from 'src/components/Title'
 import DataTable from 'src/components/tables/DataTable'
 import { ReactComponent as TxInIcon } from 'src/styling/icons/direction/cash-in.svg'
 import { ReactComponent as TxOutIcon } from 'src/styling/icons/direction/cash-out.svg'
-import { toUnit } from 'src/utils/coin'
+import { toUnit, formatCryptoAddress } from 'src/utils/coin'
 
 import DetailsRow from './DetailsCard'
 import { mainStyles } from './Transactions.styles'
@@ -111,7 +111,7 @@ const Transactions = () => {
     },
     {
       header: 'Address',
-      view: R.path(['toAddress']),
+      view: it => formatCryptoAddress(it.cryptoCode, it.toAddress),
       className: classes.overflowTd,
       size: 'sm',
       width: 140

--- a/new-lamassu-admin/src/utils/coin.js
+++ b/new-lamassu-admin/src/utils/coin.js
@@ -52,4 +52,8 @@ function toUnit(cryptoAtoms, cryptoCode) {
   return cryptoAtoms.shiftedBy(-unitScale)
 }
 
-export { toUnit }
+function formatCryptoAddress(cryptoCode = '', address = '') {
+  return cryptoCode === 'BCH' ? address.replace('bitcoincash:', '') : address
+}
+
+export { toUnit, formatCryptoAddress }


### PR DESCRIPTION
fix: removed the 'bitcoincash:' substring from bch addresses on the
admin