### PR TITLE
Fix: Make "save" always show up first on forms

### DIFF
--- a/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
+++ b/new-lamassu-admin/src/components/booleanPropertiesTable/BooleanPropertiesTable.js
@@ -59,14 +59,14 @@ const BooleanPropertiesTable = memo(
               <H4>{title}</H4>
               {editing ? (
                 <div className={classes.rightAligned}>
-                  <Link onClick={innerCancel} color="secondary">
-                    Cancel
+                  <Link type="submit" color="primary">
+                    Save
                   </Link>
                   <Link
                     className={classes.rightLink}
-                    type="submit"
-                    color="primary">
-                    Save
+                    onClick={innerCancel}
+                    color="secondary">
+                    Cancel
                   </Link>
                 </div>
               ) : (

--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -43,13 +43,14 @@ const ActionCol = ({ disabled, editing }) => {
       {editing && (
         <Td textAlign="center" width={actionColSize}>
           <Link
-            className={classes.cancelButton}
-            color="secondary"
-            onClick={resetForm}>
-            Cancel
-          </Link>
-          <Link color="primary" onClick={submitForm}>
+            className={classes.saveButton}
+            type="submit"
+            color="primary"
+            onClick={submitForm}>
             Save
+          </Link>
+          <Link color="secondary" onClick={resetForm}>
+            Cancel
           </Link>
         </Td>
       )}

--- a/new-lamassu-admin/src/components/editableTable/Row.styles.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.styles.js
@@ -1,7 +1,7 @@
 import { bySize, bold } from 'src/styling/helpers'
 
 export default {
-  cancelButton: {
+  saveButton: {
     marginRight: 20
   },
   lastOfGroup: {


### PR DESCRIPTION
fix: make save buttons always shows up prior to cancel buttons

fix: make all save buttons of submit type