### PR TITLE
fix: use p2sh-segwit addresses for cash-out

### DIFF
--- a/lib/blockchain/bitcoin.js
+++ b/lib/blockchain/bitcoin.js
@@ -24,5 +24,6 @@ server=1
 connections=40
 keypool=10000
 prune=4000
-daemon=0`
+daemon=0
+addresstype=p2sh-segwit`
 }

--- a/lib/blockchain/litecoin.js
+++ b/lib/blockchain/litecoin.js
@@ -24,5 +24,6 @@ server=1
 connections=40
 keypool=10000
 prune=4000
-daemon=0`
+daemon=0
+addresstype=p2sh-segwit`
 }


### PR DESCRIPTION
Latest releases of bitcoind default to bech32 addresses. Instead, use p2sh-segwit to maintain compatibility on cash-out.