### PR TITLE
Fix: Make every field of the notifications page optional

### DIFF
--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -102,7 +102,7 @@ const ECol = ({
     textAlign,
     suffix,
     SuffixComponent = TL2,
-    view = it => it?.toString(),
+    view = it => (!it ? '-' : it.toString()),
     inputProps = {}
   } = config
 

--- a/new-lamassu-admin/src/components/editableTable/Row.js
+++ b/new-lamassu-admin/src/components/editableTable/Row.js
@@ -102,7 +102,7 @@ const ECol = ({
     textAlign,
     suffix,
     SuffixComponent = TL2,
-    view = it => (!it ? '-' : it.toString()),
+    view = it => it?.toString(),
     inputProps = {}
   } = config
 

--- a/new-lamassu-admin/src/pages/Notifications/components/SingleFieldEditableNumber.js
+++ b/new-lamassu-admin/src/pages/Notifications/components/SingleFieldEditableNumber.js
@@ -5,6 +5,7 @@ import * as Yup from 'yup'
 import PromptWhenDirty from 'src/components/PromptWhenDirty'
 
 import NotificationsCtx from '../NotificationsContext'
+import { transformNumber } from '../helper'
 
 import Header from './EditHeader'
 import EditableNumber from './EditableNumber'
@@ -43,10 +44,11 @@ const SingleFieldEditableNumber = ({
 
   const schema = Yup.object().shape({
     [name]: Yup.number()
+      .transform(transformNumber)
       .integer()
       .min(min)
       .max(max)
-      .required()
+      .nullable()
   })
 
   return (

--- a/new-lamassu-admin/src/pages/Notifications/helper.js
+++ b/new-lamassu-admin/src/pages/Notifications/helper.js
@@ -1,0 +1,6 @@
+import _ from 'lodash/fp'
+
+const transformNumber = value =>
+  _.isNumber(value) && !_.isNaN(value) ? value : null
+
+export { transformNumber }

--- a/new-lamassu-admin/src/pages/Notifications/sections/CryptoBalanceOverrides.js
+++ b/new-lamassu-admin/src/pages/Notifications/sections/CryptoBalanceOverrides.js
@@ -7,6 +7,7 @@ import { NumberInput } from 'src/components/inputs/formik'
 import Autocomplete from 'src/components/inputs/formik/Autocomplete.js'
 
 import NotificationsCtx from '../NotificationsContext'
+import { transformNumber } from '../helper'
 
 const HIGH_BALANCE_KEY = 'highBalance'
 const LOW_BALANCE_KEY = 'lowBalance'
@@ -51,20 +52,34 @@ const CryptoBalanceOverrides = ({ section }) => {
     [HIGH_BALANCE_KEY]: ''
   }
 
+  const notesMin = 0
   const currencyMax = 9999999
-  const validationSchema = Yup.object().shape({
-    [CRYPTOCURRENCY_KEY]: Yup.string().required(),
-    [LOW_BALANCE_KEY]: Yup.number()
-      .integer()
-      .min(0)
-      .max(currencyMax)
-      .required(),
-    [HIGH_BALANCE_KEY]: Yup.number()
-      .integer()
-      .min(0)
-      .max(currencyMax)
-      .required()
-  })
+  const validationSchema = Yup.object().shape(
+    {
+      [CRYPTOCURRENCY_KEY]: Yup.string().required(),
+      [LOW_BALANCE_KEY]: Yup.number()
+        .when(HIGH_BALANCE_KEY, {
+          is: HIGH_BALANCE_KEY => !HIGH_BALANCE_KEY,
+          then: Yup.number().required()
+        })
+        .transform(transformNumber)
+        .integer()
+        .min(notesMin)
+        .max(currencyMax)
+        .nullable(),
+      [HIGH_BALANCE_KEY]: Yup.number()
+        .when(LOW_BALANCE_KEY, {
+          is: LOW_BALANCE_KEY => !LOW_BALANCE_KEY,
+          then: Yup.number().required()
+        })
+        .transform(transformNumber)
+        .integer()
+        .min(notesMin)
+        .max(currencyMax)
+        .nullable()
+    },
+    [LOW_BALANCE_KEY, HIGH_BALANCE_KEY]
+  )
 
   const viewCrypto = it =>
     R.compose(

--- a/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceAlerts.js
+++ b/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceAlerts.js
@@ -10,6 +10,7 @@ import { Cashbox } from '../../../components/inputs/cashbox/Cashbox'
 import NotificationsCtx from '../NotificationsContext'
 import Header from '../components/EditHeader'
 import EditableNumber from '../components/EditableNumber'
+import { transformNumber } from '../helper'
 
 import styles from './FiatBalanceAlerts.styles.js'
 
@@ -19,6 +20,7 @@ const NAME = 'fiatBalanceAlerts'
 
 const FiatBalance = ({
   section,
+  min = 0,
   max = Number.MAX_SAFE_INTEGER,
   fieldWidth = 80
 }) => {
@@ -31,15 +33,17 @@ const FiatBalance = ({
 
   const schema = Yup.object().shape({
     fiatBalanceCassette1: Yup.number()
+      .transform(transformNumber)
       .integer()
-      .min(0)
+      .min(min)
       .max(max)
-      .required(),
+      .nullable(),
     fiatBalanceCassette2: Yup.number()
+      .transform(transformNumber)
       .integer()
-      .min(0)
+      .min(min)
       .max(max)
-      .required()
+      .nullable()
   })
 
   const fiatBalanceCassette1Percent =

--- a/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceOverrides.js
+++ b/new-lamassu-admin/src/pages/Notifications/sections/FiatBalanceOverrides.js
@@ -7,6 +7,7 @@ import { NumberInput } from 'src/components/inputs/formik/'
 import Autocomplete from 'src/components/inputs/formik/Autocomplete'
 
 import NotificationsCtx from '../NotificationsContext'
+import { transformNumber } from '../helper'
 
 const CASSETTE_1_KEY = 'cassette1'
 const CASSETTE_2_KEY = 'cassette2'
@@ -38,20 +39,34 @@ const FiatBalanceOverrides = ({ section }) => {
     [CASSETTE_2_KEY]: ''
   }
 
+  const notesMin = 0
   const notesMax = 9999999
-  const validationSchema = Yup.object().shape({
-    [MACHINE_KEY]: Yup.string().required(),
-    [CASSETTE_1_KEY]: Yup.number()
-      .integer()
-      .min(0)
-      .max(notesMax)
-      .required(),
-    [CASSETTE_2_KEY]: Yup.number()
-      .integer()
-      .min(0)
-      .max(notesMax)
-      .required()
-  })
+  const validationSchema = Yup.object().shape(
+    {
+      [MACHINE_KEY]: Yup.string().required(),
+      [CASSETTE_1_KEY]: Yup.number()
+        .when(CASSETTE_2_KEY, {
+          is: CASSETTE_2_KEY => !CASSETTE_2_KEY,
+          then: Yup.number().required()
+        })
+        .transform(transformNumber)
+        .integer()
+        .min(notesMin)
+        .max(notesMax)
+        .nullable(),
+      [CASSETTE_2_KEY]: Yup.number()
+        .when(CASSETTE_1_KEY, {
+          is: CASSETTE_1_KEY => !CASSETTE_1_KEY,
+          then: Yup.number().required()
+        })
+        .transform(transformNumber)
+        .integer()
+        .min(notesMin)
+        .max(notesMax)
+        .nullable()
+    },
+    [CASSETTE_1_KEY, CASSETTE_2_KEY]
+  )
 
   const viewMachine = it =>
     R.compose(R.path(['name']), R.find(R.propEq('deviceId', it)))(machines)


### PR DESCRIPTION
fix: make table fields show a '-' instead of an empty string when the
col content is null

fix: make all notifications fields optional

fix: make the notifications overrides fields valid only if the machine/
cryptocurrency and at least one of the other options are filled