### PR TITLE
feat: Dropdowns should change to previous value if user closes configuration popup without saving

### DIFF
--- a/new-lamassu-admin/src/components/inputs/formik/Autocomplete.js
+++ b/new-lamassu-admin/src/components/inputs/formik/Autocomplete.js
@@ -24,7 +24,7 @@ const AutocompleteFormik = ({ options, onChange, ...props }) => {
     <Autocomplete
       name={name}
       onChange={(event, item) => {
-        onChange && onChange(value, item)
+        onChange && onChange(value, item, () => setFieldValue(name, value))
         setFieldValue(name, item)
       }}
       onBlur={innerOnBlur}

--- a/new-lamassu-admin/src/pages/Locales/helper.js
+++ b/new-lamassu-admin/src/pages/Locales/helper.js
@@ -5,14 +5,14 @@ import Autocomplete from 'src/components/inputs/formik/Autocomplete.js'
 
 const LANGUAGE_SELECTION_LIMIT = 4
 
-const getFields = (getData, names, enableCoin, auxElements = []) => {
+const getFields = (getData, names, configureCoin, auxElements = []) => {
   return R.filter(
     it => R.includes(it.name, names),
-    allFields(getData, enableCoin, auxElements)
+    allFields(getData, configureCoin, auxElements)
   )
 }
 
-const allFields = (getData, enableCoin, auxElements = []) => {
+const allFields = (getData, configureCoin, auxElements = []) => {
   const getView = (data, code, compare) => it => {
     if (!data) return ''
 
@@ -108,29 +108,30 @@ const allFields = (getData, enableCoin, auxElements = []) => {
         getLabel: R.path(['code']),
         multiple: true,
         optionsLimit: null,
-        onChange: (prev, curr) => enableCoin(R.difference(curr, prev)[0])
+        onChange: (prev, curr, cancel) =>
+          configureCoin(R.difference(curr, prev)[0], prev, cancel)
       }
     }
   ]
 }
 
-const mainFields = (auxData, enableCoin) => {
+const mainFields = (auxData, configureCoin) => {
   const getData = R.path(R.__, auxData)
 
   return getFields(
     getData,
     ['country', 'fiatCurrency', 'languages', 'cryptoCurrencies'],
-    enableCoin
+    configureCoin
   )
 }
 
-const overrides = (auxData, auxElements, enableCoin) => {
+const overrides = (auxData, auxElements, configureCoin) => {
   const getData = R.path(R.__, auxData)
 
   return getFields(
     getData,
     ['machine', 'country', 'languages', 'cryptoCurrencies'],
-    enableCoin,
+    configureCoin,
     auxElements
   )
 }

--- a/new-lamassu-admin/src/pages/Wallet/Wallet.js
+++ b/new-lamassu-admin/src/pages/Wallet/Wallet.js
@@ -45,6 +45,9 @@ const GET_INFO = gql`
 
 const Wallet = ({ name: SCREEN_KEY }) => {
   const [editingSchema, setEditingSchema] = useState(null)
+  const [cancelServiceConfiguration, setCancelServiceConfiguration] = useState(
+    null
+  )
   const [wizard, setWizard] = useState(false)
   const [error, setError] = useState(false)
   const { data } = useQuery(GET_INFO)
@@ -71,10 +74,13 @@ const Wallet = ({ name: SCREEN_KEY }) => {
   const cryptoCurrencies = data?.cryptoCurrencies ?? []
   const accounts = data?.accounts ?? []
 
-  const enableThirdPartyService = it => {
+  const configureThirdPartyService = (it, cancel) => {
     if (!it) return
 
-    if (!accounts[it]) return setEditingSchema(schemas[it])
+    if (!accounts[it]) {
+      setEditingSchema(schemas[it])
+      setCancelServiceConfiguration(() => () => cancel())
+    }
   }
 
   const shouldOverrideEdit = it => {
@@ -99,7 +105,7 @@ const Wallet = ({ name: SCREEN_KEY }) => {
         elements={getElements(
           cryptoCurrencies,
           accountsConfig,
-          enableThirdPartyService
+          configureThirdPartyService
         )}
       />
       {wizard && (
@@ -118,7 +124,10 @@ const Wallet = ({ name: SCREEN_KEY }) => {
         <Modal
           title={`Edit ${editingSchema.name}`}
           width={478}
-          handleClose={() => setEditingSchema(null)}
+          handleClose={() => {
+            cancelServiceConfiguration && cancelServiceConfiguration()
+            setEditingSchema(null)
+          }}
           open={true}>
           <FormRenderer
             save={it =>

--- a/new-lamassu-admin/src/pages/Wallet/helper.js
+++ b/new-lamassu-admin/src/pages/Wallet/helper.js
@@ -16,7 +16,7 @@ const WalletSchema = Yup.object().shape({
 const getElements = (
   cryptoCurrencies,
   accounts,
-  enableThirdPartyService,
+  configureThirdPartyService,
   wizard = false
 ) => {
   const widthAdjust = wizard ? 11 : 0
@@ -38,7 +38,8 @@ const getElements = (
     filterCoins(it)(filterOptions(option))
   )
 
-  const onChange = (prev, curr) => enableThirdPartyService(curr)
+  const onChange = (prev, curr, cancel) =>
+    configureThirdPartyService(curr, cancel)
 
   return [
     {


### PR DESCRIPTION
fix: keep previous value when closing the configuration popup without
saving on locales screen

refactor: renamed enableCoin function to configureCoin

fix: keep previous value when closing the configuration popup without
saving on wallets screen

refactor: renamed enableThirdPartyService function to
configureThirdPartyService