### PR TITLE
fix: cash out transaction status pending despite being successful 0conf dispense

### DIFF
--- a/new-lamassu-admin/src/pages/Transactions/helper.js
+++ b/new-lamassu-admin/src/pages/Transactions/helper.js
@@ -14,7 +14,7 @@ const getCashInStatus = it => {
 }
 
 const getStatus = it => {
-  if (it.class === 'cashOut') {
+  if (it.txClass === 'cashOut') {
     return getCashOutStatus(it)
   }
   return getCashInStatus(it)


### PR DESCRIPTION
fix: wrong property was being used to determine if a tx was cash-in or
cash-out on the transactions page, resulting in wrong cash-out status on
the page