### PR TITLE
fix: High-value transaction notifications not triggering

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -355,7 +355,7 @@ function plugins (settings, deviceId) {
     const notificationsEnabled = notifications.sms.transactions || notifications.email.transactions
     const highValueTx = tx.fiat.gt(notifications.highValueTransaction || Infinity)
 
-    if (!notificationsEnabled || !highValueTx) return Promise.resolve()
+    if (!notificationsEnabled && !highValueTx) return Promise.resolve()
 
     const isCashOut = tx.direction === 'cashOut'
     const zeroConf = isCashOut && isZeroConf(tx)
@@ -393,9 +393,9 @@ function plugins (settings, deviceId) {
         - Customer: ${customerName}
         ${phone}
       `
-        const subject = `A transaction just happened`
+        const subject = `A ${highValueTx ? 'high value ' : ''}transaction just happened`
 
-        return {
+        return [{
           sms: {
             body: `${subject} - ${status}`
           },
@@ -403,9 +403,9 @@ function plugins (settings, deviceId) {
             subject,
             body
           }
-        }
+        }, highValueTx]
       })
-      .then(sendTransactionMessage)
+      .then(([rec, highValueTx]) => sendTransactionMessage(rec, highValueTx))
   }
 
   function sendRedemptionMessage (txId, error) {
@@ -611,15 +611,15 @@ function plugins (settings, deviceId) {
     return Promise.all(promises)
   }
 
-  function sendTransactionMessage (rec) {
+  function sendTransactionMessage (rec, isHighValueTx) {
     const notifications = configManager.getGlobalNotifications(settings.config)
 
     let promises = []
 
-    const emailActive = notifications.email.active && notifications.email.transactions
+    const emailActive = notifications.email.active && (notifications.email.transactions || isHighValueTx)
     if (emailActive) promises.push(email.sendMessage(settings, rec))
 
-    const smsActive = notifications.sms.active && notifications.sms.transactions
+    const smsActive = notifications.sms.active && (notifications.sms.transactions || isHighValueTx)
     if (smsActive) promises.push(sms.sendMessage(settings, rec))
 
     return Promise.all(promises)


### PR DESCRIPTION
fix: high value notifications, if configured, are now triggered even if
transactions notifications are globally disabled (for sms or email)

fix: added extra information on the sms notification informing if the
transaction that just happened is a high value one