### PR TITLE
fix: Fiat balance cassette amount alerts not triggering

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -706,10 +706,10 @@ function plugins (settings, deviceId) {
       fiatCode,
     }
 
-    if (BN(fiatBalance.balance).lt(lowAlertThreshold))
+    if (lowAlertThreshold && BN(fiatBalance.balance).lt(lowAlertThreshold))
       return _.set('code')('LOW_CRYPTO_BALANCE')(req)
 
-    if (BN(fiatBalance.balance).gt(highAlertThreshold))
+    if (highAlertThreshold && BN(fiatBalance.balance).gt(highAlertThreshold))
       return _.set('code')('HIGH_CRYPTO_BALANCE')(req)
 
     return null

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -706,10 +706,10 @@ function plugins (settings, deviceId) {
       fiatCode,
     }
 
-    if (lowAlertThreshold && BN(fiatBalance.balance).lt(lowAlertThreshold))
+    if (_.isFinite(lowAlertThreshold) && BN(fiatBalance.balance).lt(lowAlertThreshold))
       return _.set('code')('LOW_CRYPTO_BALANCE')(req)
 
-    if (highAlertThreshold && BN(fiatBalance.balance).gt(highAlertThreshold))
+    if (_.isFinite(highAlertThreshold) && BN(fiatBalance.balance).gt(highAlertThreshold))
       return _.set('code')('HIGH_CRYPTO_BALANCE')(req)
 
     return null


### PR DESCRIPTION
fix: removed the attempts to use the bignumber.js lib with null values