### PR TITLE
fix: Compliance triggers allowing to create a suspend trigger with no days set

### DIFF
--- a/new-lamassu-admin/src/pages/Triggers/helper.js
+++ b/new-lamassu-admin/src/pages/Triggers/helper.js
@@ -76,7 +76,10 @@ const threshold = Yup.object().shape({
 })
 const requirement = Yup.object().shape({
   requirement: Yup.string().required(),
-  suspensionDays: Yup.number()
+  suspensionDays: Yup.number().when('requirement', {
+    is: 'suspend',
+    then: Yup.number().required()
+  })
 })
 
 const Schema = Yup.object().shape({


### PR DESCRIPTION
fix: make the number of suspension days required only when the
'Suspend' requirement is selected