### PR TITLE
fix: Record outgoing transaction fees to logs

### DIFF
--- a/lib/new-admin/graphql/resolvers/transaction.resolver.js
+++ b/lib/new-admin/graphql/resolvers/transaction.resolver.js
@@ -5,6 +5,17 @@ const transactions = require('../../services/transactions')
 const anonymous = require('../../../constants').anonymousCustomer
 
 const transactionsLoader = new DataLoader(ids => transactions.getCustomerTransactionsBatch(ids))
+const tx_logFields = ["txClass", "id", "deviceId", "toAddress", "cryptoAtoms", 
+                   "cryptoCode", "fiat", "fiatCode", "fee", "status", 
+                   "dispense", "notified", "redeem", "phone", "error",
+                   "created", "confirmedAt", "hdIndex", "swept", "timedout",
+                   "dispenseConfirmed", "provisioned1", "provisioned2", 
+                   "denomination1", "denomination2", "errorCode", "customerId",
+                   "txVersion", "publishedAt", "termsAccepted", "layer2Address",
+                   "commissionPercentage", "rawTickerPrice", "receivedCryptoAtoms",
+                   "discount", "txHash", "customerPhone", "customerIdCardDataNumber",
+                   "customerIdCardDataExpiration", "customerIdCardData", "customerName",
+                   "customerFrontCameraPath", "customerIdCardPhotoPath", "expired", "machineName"]
 
 const resolvers = {
   Customer: {
@@ -17,7 +28,7 @@ const resolvers = {
     transactions: (...[, { from, until, limit, offset, deviceId }]) =>
       transactions.batch(from, until, limit, offset, deviceId),
     transactionsCsv: (...[, { from, until, limit, offset }]) =>
-      transactions.batch(from, until, limit, offset).then(parseAsync)
+      transactions.batch(from, until, limit, offset).then(data => parseAsync(data, {fields: tx_logFields}))
   }
 }
 


### PR DESCRIPTION
Seems to be a problem with the current version of the 'json2csv' package, which is omiting some fields coming from the txCSV log query.
Tried to specify to include empty fields, but to no avail. 
Only worked if I specified all field to be parsed.