### PR TITLE
Fix: throws errors on pazuz-wallet newAddress

### DIFF
--- a/lib/plugins/wallet/pazuz-wallet/pazuz-wallet.js
+++ b/lib/plugins/wallet/pazuz-wallet/pazuz-wallet.js
@@ -64,6 +64,7 @@ function newAddress (account, info, tx, settings, operatorId) {
       operatorId
     }))
     .then(({ data }) => {
+      if(data.error) throw new Error(JSON.stringify(data.error))
       return data.newAddress
     })
 }


### PR DESCRIPTION
we weren't handling errors on newAddress and it was breaking the code on l-m