### PR TITLE
Fix coin installation restarting previously killed supervisor processes

### DIFF
--- a/lib/blockchain/install.js
+++ b/lib/blockchain/install.js
@@ -56,7 +56,8 @@ function processCryptos (codes) {
 
   const selectedCryptos = _.map(code => _.find(['code', code], cryptos), codes)
   _.forEach(setupCrypto, selectedCryptos)
-  common.es('sudo service supervisor restart')
+  common.es('sudo supervisorctl reread')
+  common.es('sudo supervisorctl update')
 
   const blockchainDir = coinUtils.blockchainDir()
   const backupDir = path.resolve(os.homedir(), 'backups')


### PR DESCRIPTION
fix: use supervisor reload instead of restart

fix: set blockchain process autorestart to unexpected

fix: use supervisor reload and update instead of restart

fix: stop restarting supervisor service

fix: set blockchain supervisor config autorestart