### PR TITLE
fix: expired column in customer transactions history

### DIFF
--- a/lib/admin/transactions.js
+++ b/lib/admin/transactions.js
@@ -33,7 +33,7 @@ function batch () {
   order by created desc limit $2`
 
   const cashOutSql = `select 'cashOut' as tx_class, cash_out_txs.*,
-  (extract(epoch from (now() - greatest(created, confirmed_at))) * 1000) >= $2 as expired
+  (NOT dispense AND extract(epoch from (now() - greatest(created, confirmed_at))) >= $2) as expired
   from cash_out_txs
   order by created desc limit $1`
 
@@ -51,7 +51,7 @@ function single (txId) {
   where id=$2`
 
   const cashOutSql = `select 'cashOut' as tx_class, 
-  (extract(epoch from (now() - greatest(created, confirmed_at))) * 1000) >= $2 as expired,
+  (NOT dispense AND extract(epoch from (now() - greatest(created, confirmed_at))) >= $2) as expired,
   cash_out_txs.*
   from cash_out_txs
   where id=$1`

--- a/lib/cash-out/cash-out-helper.js
+++ b/lib/cash-out/cash-out-helper.js
@@ -4,7 +4,9 @@ const db = require('../db')
 const T = require('../time')
 const BN = require('../bn')
 
-const REDEEMABLE_AGE = T.day
+// FP operations on Postgres result in very big errors.
+// E.g.: 1853.013808 * 1000 = 1866149.494
+const REDEEMABLE_AGE = T.day / 1000
 
 module.exports = { redeemableTxs, toObj, toDb, REDEEMABLE_AGE }
 
@@ -101,7 +103,7 @@ function redeemableTxs (deviceId) {
   and redeem=$2
   and dispense=$3
   and provisioned_1 is not null
-  and (extract(epoch from (now() - greatest(created, confirmed_at))) * 1000) < $4`
+  and extract(epoch from (now() - greatest(created, confirmed_at))) < $4`
 
   return db.any(sql, [deviceId, true, false, REDEEMABLE_AGE])
     .then(_.map(toObj))

--- a/lib/new-admin/transactions.js
+++ b/lib/new-admin/transactions.js
@@ -55,7 +55,7 @@ function batch (from = new Date(0).toISOString(), until = new Date().toISOString
   c.name as customer_name,
   c.front_camera_path as customer_front_camera_path,
   c.id_card_photo_path as customer_id_card_photo_path,
-  (extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) * 1000) >= $1 as expired
+  (NOT txs.dispense AND extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) >= $1) as expired
   from cash_out_txs txs
   inner join cash_out_actions actions on txs.id = actions.tx_id
   and actions.action = 'provisionAddress'
@@ -156,7 +156,7 @@ function getCustomerTransactionsBatch (ids) {
   c.name as customer_name,
   c.front_camera_path as customer_front_camera_path,
   c.id_card_photo_path as customer_id_card_photo_path,
-  (extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) * 1000) >= $3 as expired
+  (NOT txs.dispense AND extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) >= $3) as expired
   from cash_out_txs txs
   inner join cash_out_actions actions on txs.id = actions.tx_id
   and actions.action = 'provisionAddress'
@@ -199,7 +199,7 @@ function single (txId) {
   c.name as customer_name,
   c.front_camera_path as customer_front_camera_path,
   c.id_card_photo_path as customer_id_card_photo_path,
-  (extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) * 1000) >= $2 as expired
+  (NOT txs.dispense AND extract(epoch from (now() - greatest(txs.created, txs.confirmed_at))) >= $2) as expired
   from cash_out_txs txs
   inner join cash_out_actions actions on txs.id = actions.tx_id
   and actions.action = 'provisionAddress'

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -5,7 +5,9 @@ const CashInTx = require('./cash-in/cash-in-tx')
 const CashOutTx = require('./cash-out/cash-out-tx')
 const T = require('./time')
 
-const REDEEMABLE_AGE = T.day
+// FP operations on Postgres result in very big errors.
+// E.g.: 1853.013808 * 1000 = 1866149.494
+const REDEEMABLE_AGE = T.day / 1000
 
 function process (tx, pi) {
   const mtx = massage(tx, pi)
@@ -76,7 +78,7 @@ function customerHistory (customerId, thresholdDays) {
       AND txIn.created > now() - interval $2
     UNION
     SELECT txOut.id, txOut.created, txOut.fiat, 'cashOut' AS direction,
-      (extract(epoch FROM (now() - greatest(txOut.created, txOut.confirmed_at))) * 1000) >= $4 AS expired
+      (NOT txOut.dispense AND extract(epoch FROM (now() - greatest(txOut.created, txOut.confirmed_at))) >= $4) AS expired
       FROM cash_out_txs txOut
       WHERE txOut.customer_id = $1
       AND txOut.created > now() - interval $2


### PR DESCRIPTION
I initially had two seperate commits, one to fix the `expired` column, and another to improve FP precision, but while touching up the first commit with `git rebase` I must have accidentally merged the other into it... I started trying to fix it but it was taking too much effort, and thought it wasn't worth it. Let me know if you want two separate commits and I can do it.