### PR TITLE
Revert "Fix: overflow shorthand override warning"

### DIFF
--- a/new-lamassu-admin/src/components/tables/DataTable.js
+++ b/new-lamassu-admin/src/components/tables/DataTable.js
@@ -184,11 +184,7 @@ const DataTable = ({
             {({ height }) => (
               <List
                 // this has to be in a style because of how the component works
-                style={{
-                  overflowX: 'inherit',
-                  overflowY: 'inherit',
-                  outline: 'none'
-                }}
+                style={{ overflow: 'inherit', outline: 'none' }}
                 {...props}
                 height={loading ? 0 : height}
                 width={width}


### PR DESCRIPTION
This reverts commit b1771df66dc5942eaafe65e6dd549eda15c6b9df.