### PR TITLE
Fix fiat balance percentage notification overrides being ignored

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,7 +5,7 @@ const anonymousCustomer = {
   name: 'anonymous'
 }
 
-const cassetteMaxCapacity = 500
+const CASSETTE_MAX_CAPACITY = 500
 
 const AUTHENTICATOR_ISSUER_ENTITY = 'Lamassu'
 const AUTH_TOKEN_EXPIRATION_TIME = '30 minutes'
@@ -21,7 +21,7 @@ const CONFIRMATION_CODE = 'sms_code'
 
 module.exports = {
   anonymousCustomer,
-  cassetteMaxCapacity,
+  CASSETTE_MAX_CAPACITY,
   AUTHENTICATOR_ISSUER_ENTITY,
   AUTH_TOKEN_EXPIRATION_TIME,
   REGISTRATION_TOKEN_EXPIRATION_TIME,

--- a/lib/new-admin/services/machines.js
+++ b/lib/new-admin/services/machines.js
@@ -6,7 +6,7 @@ function getMachine (machineId) {
     .then(machines => machines.find(({ deviceId }) => deviceId === machineId))
 }
 
-function machineAction ({ deviceId, action, cashbox, cassette1, cassette2, cassette3, cassette4, newName }) {
+function machineAction ({ deviceId, action, cashbox, cassette1, cassette2, cassette3, cassette4, newName }, context) {
   const operatorId = context.res.locals.operatorId
   return getMachine(deviceId)
     .then(machine => {

--- a/lib/new-config-manager.js
+++ b/lib/new-config-manager.js
@@ -82,7 +82,7 @@ const getNotifications = (cryptoCurrency, machine, config) => {
   const findByMachine = _.find(_.matches({ machine }))
 
   const cryptoFields = ['cryptoHighBalance', 'cryptoLowBalance', 'highBalance', 'lowBalance']
-  const fiatFields = ['fiatBalanceCassette1', 'fiatBalanceCassette2', 'fiatBalanceCassette3', 'fiatBalanceCassette4']
+  const fiatFields = ['fillingPercentageCassette1', 'fillingPercentageCassette2', 'fillingPercentageCassette3', 'fillingPercentageCassette4']
 
   const getCryptoSettings = _.compose(_.pick(cryptoFields), _.defaultTo(notifications), findByCryptoCurrency)
   const cryptoSettings = getCryptoSettings(notifications.cryptoBalanceOverrides)

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -26,7 +26,7 @@ const commissionMath = require('./commission-math')
 const loyalty = require('./loyalty')
 const transactionBatching = require('./tx-batching')
 
-const { cassetteMaxCapacity, CASH_OUT_DISPENSE_READY, CONFIRMATION_CODE } = require('./constants')
+const { CASSETTE_MAX_CAPACITY, CASH_OUT_DISPENSE_READY, CONFIRMATION_CODE } = require('./constants')
 
 const notifier = require('./notifier')
 
@@ -657,7 +657,7 @@ function plugins (settings, deviceId) {
       }
       : null
 
-    const cassette1Alert = device.numberOfCassettes >= 1 && isCassetteLow(device.cassette1, cassetteMaxCapacity, notifications.fillingPercentageCassette1)
+    const cassette1Alert = device.numberOfCassettes >= 1 && isCassetteLow(device.cassette1, CASSETTE_MAX_CAPACITY, notifications.fillingPercentageCassette1)
       ? {
         code: 'LOW_CASH_OUT',
         cassette: 1,
@@ -669,7 +669,7 @@ function plugins (settings, deviceId) {
       }
       : null
 
-    const cassette2Alert = device.numberOfCassettes >= 2 && isCassetteLow(device.cassette2, cassetteMaxCapacity, notifications.fillingPercentageCassette2)
+    const cassette2Alert = device.numberOfCassettes >= 2 && isCassetteLow(device.cassette2, CASSETTE_MAX_CAPACITY, notifications.fillingPercentageCassette2)
       ? {
         code: 'LOW_CASH_OUT',
         cassette: 2,
@@ -681,7 +681,7 @@ function plugins (settings, deviceId) {
       }
       : null
 
-    const cassette3Alert = device.numberOfCassettes >= 3 && isCassetteLow(device.cassette3, cassetteMaxCapacity, notifications.fillingPercentageCassette3)
+    const cassette3Alert = device.numberOfCassettes >= 3 && isCassetteLow(device.cassette3, CASSETTE_MAX_CAPACITY, notifications.fillingPercentageCassette3)
       ? {
         code: 'LOW_CASH_OUT',
         cassette: 3,
@@ -693,7 +693,7 @@ function plugins (settings, deviceId) {
       }
       : null
 
-    const cassette4Alert = device.numberOfCassettes >= 4 && isCassetteLow(device.cassette4, cassetteMaxCapacity, notifications.fillingPercentageCassette4)
+    const cassette4Alert = device.numberOfCassettes >= 4 && isCassetteLow(device.cassette4, CASSETTE_MAX_CAPACITY, notifications.fillingPercentageCassette4)
       ? {
         code: 'LOW_CASH_OUT',
         cassette: 4,

--- a/migrations/1619968992683-fiat-balance-notification-to-percent.js
+++ b/migrations/1619968992683-fiat-balance-notification-to-percent.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { saveConfig, loadLatest } = require('../lib/new-settings-loader')
-const { cassetteMaxCapacity } = require('../lib/constants')
+const { CASSETTE_MAX_CAPACITY } = require('../lib/constants')
 
 exports.up = function (next) {
   return loadLatest()
@@ -12,19 +12,19 @@ exports.up = function (next) {
       const overrides = config.notifications_fiatBalanceOverrides
       const newConfig = {}
       if (fiatBalance1) {
-        newConfig.notifications_fillingPercentageCassette1 = (100 * (fiatBalance1 / cassetteMaxCapacity)).toFixed(0)
+        newConfig.notifications_fillingPercentageCassette1 = (100 * (fiatBalance1 / CASSETTE_MAX_CAPACITY)).toFixed(0)
         newConfig.notifications_fiatBalanceCassette1 = null
       }
       if (fiatBalance2) {
-        newConfig.notifications_fillingPercentageCassette2 = (100 * (fiatBalance2 / cassetteMaxCapacity)).toFixed(0)
+        newConfig.notifications_fillingPercentageCassette2 = (100 * (fiatBalance2 / CASSETTE_MAX_CAPACITY)).toFixed(0)
         newConfig.notifications_fiatBalanceCassette2 = null
       }
       if (fiatBalance3) {
-        newConfig.notifications_fillingPercentageCassette3 = (100 * (fiatBalance3 / cassetteMaxCapacity)).toFixed(0)
+        newConfig.notifications_fillingPercentageCassette3 = (100 * (fiatBalance3 / CASSETTE_MAX_CAPACITY)).toFixed(0)
         newConfig.notifications_fiatBalanceCassette3 = null
       }
       if (fiatBalance4) {
-        newConfig.notifications_fillingPercentageCassette4 = (100 * (fiatBalance4 / cassetteMaxCapacity)).toFixed(0)
+        newConfig.notifications_fillingPercentageCassette4 = (100 * (fiatBalance4 / CASSETTE_MAX_CAPACITY)).toFixed(0)
         newConfig.notifications_fiatBalanceCassette4 = null
       }
 
@@ -32,16 +32,16 @@ exports.up = function (next) {
         newConfig.notifications_fiatBalanceOverrides = _.map(override => {
           const newOverride = {}
           if (override.fiatBalanceCassette1) {
-            newOverride.fillingPercentageCassette1 = (100 * (override.fiatBalanceCassette1 / cassetteMaxCapacity)).toFixed(0)
+            newOverride.fillingPercentageCassette1 = (100 * (override.fiatBalanceCassette1 / CASSETTE_MAX_CAPACITY)).toFixed(0)
           }
           if (override.fiatBalanceCassette2) {
-            newOverride.fillingPercentageCassette2 = (100 * (override.fiatBalanceCassette2 / cassetteMaxCapacity)).toFixed(0)
+            newOverride.fillingPercentageCassette2 = (100 * (override.fiatBalanceCassette2 / CASSETTE_MAX_CAPACITY)).toFixed(0)
           }
           if (override.fiatBalanceCassette3) {
-            newOverride.fillingPercentageCassette3 = (100 * (override.fiatBalanceCassette3 / cassetteMaxCapacity)).toFixed(0)
+            newOverride.fillingPercentageCassette3 = (100 * (override.fiatBalanceCassette3 / CASSETTE_MAX_CAPACITY)).toFixed(0)
           }
           if (override.fiatBalanceCassette4) {
-            newOverride.fillingPercentageCassette4 = (100 * (override.fiatBalanceCassette4 / cassetteMaxCapacity)).toFixed(0)
+            newOverride.fillingPercentageCassette4 = (100 * (override.fiatBalanceCassette4 / CASSETTE_MAX_CAPACITY)).toFixed(0)
           }
           newOverride.machine = override.machine
           newOverride.id = override.id

--- a/new-lamassu-admin/src/pages/Maintenance/CashCassettes.js
+++ b/new-lamassu-admin/src/pages/Maintenance/CashCassettes.js
@@ -179,6 +179,7 @@ const CashCassettes = () => {
         }
       })
     }
+
     return setCassetteBills({
       variables: {
         action: 'setCassetteBills',

--- a/new-lamassu-admin/src/pages/Maintenance/Wizard/Wizard.js
+++ b/new-lamassu-admin/src/pages/Maintenance/Wizard/Wizard.js
@@ -1,5 +1,3 @@
-import { useMutation } from '@apollo/react-hooks'
-import gql from 'graphql-tag'
 import * as R from 'ramda'
 import React, { useState } from 'react'
 import * as Yup from 'yup'
@@ -13,21 +11,11 @@ const MODAL_WIDTH = 554
 const MODAL_HEIGHT = 520
 const CASHBOX_DEFAULT_CAPACITY = 500
 
-const CREATE_BATCH = gql`
-  mutation createBatch($deviceId: ID, $cashboxCount: Int) {
-    createBatch(deviceId: $deviceId, cashboxCount: $cashboxCount) {
-      id
-    }
-  }
-`
-
 const Wizard = ({ machine, cashoutSettings, locale, onClose, save, error }) => {
   const [{ step, config }, setState] = useState({
     step: 0,
     config: { active: true }
   })
-
-  const [createBatch] = useMutation(CREATE_BATCH)
 
   const isCashOutDisabled =
     R.isEmpty(cashoutSettings) || !cashoutSettings?.active
@@ -49,15 +37,6 @@ const Wizard = ({ machine, cashoutSettings, locale, onClose, save, error }) => {
       ].includes('YES')
 
       const cashbox = wasCashboxEmptied ? 0 : machine?.cashbox
-
-      if (wasCashboxEmptied) {
-        createBatch({
-          variables: {
-            deviceId: machine.id,
-            cashboxCount: machine.cashbox
-          }
-        })
-      }
 
       const { cassette1, cassette2, cassette3, cassette4 } = R.map(parseInt, it)
       save(machine.id, cashbox, cassette1, cassette2, cassette3, cassette4)


### PR DESCRIPTION
fix: remove duplicated createBatch() calls
fix: rename cassetteMaxCapacity to snake uppercase
fix: notification module retrieving the wrong override fields