### PR TITLE
fix: prevent bitcoind v22 from trodding on bch port

### DIFF
--- a/lib/blockchain/bitcoin.js
+++ b/lib/blockchain/bitcoin.js
@@ -48,5 +48,6 @@ addresstype=p2sh-segwit
 changetype=bech32
 walletrbf=1
 bind=0.0.0.0:8332
-rpcport=8333`
+rpcport=8333
+listenonion=0`
 }

--- a/lib/blockchain/bitcoincash.js
+++ b/lib/blockchain/bitcoincash.js
@@ -45,6 +45,6 @@ maxconnections=40
 keypool=10000
 prune=4000
 daemon=0
-bind=0.0.0.0:8334
-rpcport=8335`
+bind=0.0.0.0:8335
+rpcport=8336`
 }


### PR DESCRIPTION
https://github.com/lamassu/lamassu-coins/pull/2