### PR TITLE
LAM-1500 fix: compliance trigger set with no triggers

### DIFF
--- a/packages/server/lib/compliance-triggers.js
+++ b/packages/server/lib/compliance-triggers.js
@@ -5,7 +5,7 @@ const {
 } = require('typesafe-db')
 
 const maxDaysThreshold = triggers =>
-  Math.max(...triggers.map(t => t.thresholdDays))
+  Math.max(...[{ thresholdDays: 0 }].concat(triggers).map(t => t.thresholdDays))
 
 const getCashLimit = triggers =>
   Math.min(

--- a/packages/server/lib/machine-settings.js
+++ b/packages/server/lib/machine-settings.js
@@ -76,7 +76,7 @@ const getTriggersByMachine = (machines, machineGroups, complianceTriggers) => {
     machineGroups.map(({ id, complianceTriggerSetId }) => [
       id,
       // Machine groups with no compliance trigger set have no compliance triggers.
-      complianceTriggerSetId ? triggersBySet[complianceTriggerSetId] : [],
+      triggersBySet[complianceTriggerSetId] ?? [],
     ]),
   )
 


### PR DESCRIPTION
If a compliance trigger set doesn't have any triggers, it won't show up in `triggersBySet`.